### PR TITLE
feat(metrics): expose meteoswiss_mcp_build_info gauge

### DIFF
--- a/packages/meteoswiss-mcp/src/support/metrics.ts
+++ b/packages/meteoswiss-mcp/src/support/metrics.ts
@@ -5,6 +5,7 @@
  */
 
 import { Registry, Counter, Histogram, Gauge, collectDefaultMetrics } from 'prom-client';
+import { getVersion } from './version.js';
 
 let enabled = false;
 
@@ -46,6 +47,14 @@ export function initMetrics(metricsEnabled: boolean): void {
     help: 'Number of currently active MCP sessions',
     registers: [register],
   });
+
+  const buildInfoGauge = new Gauge({
+    name: 'meteoswiss_mcp_build_info',
+    help: 'MeteoSwiss MCP server build information',
+    labelNames: ['version', 'node_version'] as const,
+    registers: [register],
+  });
+  buildInfoGauge.labels({ version: getVersion(), node_version: process.version }).set(1);
 
   collectDefaultMetrics({ register });
 }


### PR DESCRIPTION
## Summary

- Adds `meteoswiss_mcp_build_info` gauge following the standard Prometheus build_info convention (gauge = 1 with descriptive labels)
- Labels: `version` (from `package.json` via `getVersion()`) and `node_version` (from `process.version`)
- Enables Grafana dashboard panels to display the deployed app version string

## Why

The MeteoSwiss MCP Grafana dashboard needs to show which version is deployed on TEST vs PROD. Without a version metric, dashboard panels have no way to display app version info. This follows the same convention used by `node_exporter` (`node_exporter_build_info`), `go_build_info`, and `grafana_build_info`.

## Test plan

- [ ] Build passes: `pnpm run lint:ts && pnpm run build`
- [ ] After deploy: `curl https://<host>/metrics | grep meteoswiss_mcp_build_info` shows `meteoswiss_mcp_build_info{node_version="v24.x.x",version="2.x.x"} 1`
- [ ] Grafana dashboard "Deployments" panels show version string once metric is scraped

> Note: This is separate from PR #43 and #45. Deploy to TEST first, then PROD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)