### PR TITLE
fix(test): serialize Jest workers on CI to prevent integration test boot-race

### DIFF
--- a/docs/sessionlogs/2026-04-18-mcp-harness-flake-fix.md
+++ b/docs/sessionlogs/2026-04-18-mcp-harness-flake-fix.md
@@ -1,0 +1,56 @@
+# MCP Integration Test Boot-Race Flake — Fix
+
+**Date:** 2026-04-18  
+**Session type:** Bug fix (CI test flake)  
+**Operator:** Claude Sonnet 4.6 (automated session)  
+**Branch:** `worktree-mcp-harness-flake`  
+**PR:** https://github.com/eins78/meteoswiss-llm-tools/pull/86
+
+---
+
+## Flake Signature
+
+PR #83 (trivial 27-line addition of a `meteoswiss_mcp_build_info` Prometheus gauge in `support/metrics.ts`) failed CI twice in a row:
+
+- **Attempt 1** (2026-04-18 20:03Z): `test/integration/search-multiword.test.ts` port 38540
+- **Attempt 2** (2026-04-18 20:34Z): `test/integration/meteoswiss-search.test.ts` port 35392
+
+Both threw:
+```
+Server failed to start in time (100 attempts on port NNNNN)
+  at MCPClient.waitForServer (test/integration/mcp-client.ts:73:11)
+```
+
+Different test files and different ports each attempt — classic race condition, not a deterministic bug.
+
+## Root Cause
+
+**13 integration test files** each call `MCPClient.start()` which spawns two child processes:
+1. `node dist/index.js <port>` — the MCP HTTP server
+2. `npx mcp-remote http://localhost:<port>/mcp` — the protocol bridge
+
+`waitForServer` polls TCP connect every 300 ms for up to 100 attempts (30-second budget). With no `maxWorkers` cap in `jest.config.js`, Jest runs multiple test suites concurrently on the 2-vCPU GitHub Actions runner. Under CPU starvation from 13 concurrent server+mcp-remote process pairs, some Node.js server processes can't complete event-loop initialization within the 30-second window.
+
+The failing test rotates between runs because the outcome depends on OS scheduler timing.
+
+Secondary observation: `mcp-client.ts` has no `exit` event handler on the server process. A silent crash (e.g., from a port conflict) goes undetected — the test just polls until timeout. This is a latent defect, not the root cause here.
+
+## Fix
+
+One line added to `packages/meteoswiss-mcp/jest.config.js`:
+
+```js
+maxWorkers: process.env.CI ? 1 : '50%',
+```
+
+GitHub Actions automatically injects `CI=true`, so CI serializes all Jest test workers (eliminating concurrency between integration tests) while local dev keeps the default 50%-of-CPUs parallel behavior.
+
+## Local Reproduction
+
+Did not reproduce locally (Mac Mini M4 Pro has sufficient CPUs to absorb the concurrency). Ran `pnpm test` 3× — stable 19/20 suites passing each time. The 1 failing suite (`port-mapping.test.ts`) is the pre-existing macOS parallel-Jest flake documented in project memory — unrelated to this fix.
+
+Fix correctness relies on CI for definitive verification (consistent reproduction on 2-vCPU runners).
+
+## Files Changed
+
+- `packages/meteoswiss-mcp/jest.config.js` — +1 line, no changeset (test-infra change)

--- a/packages/meteoswiss-mcp/jest.config.js
+++ b/packages/meteoswiss-mcp/jest.config.js
@@ -17,6 +17,7 @@ export default {
   testPathIgnorePatterns: ['/node_modules/', '/dist/', '/.claude/plugins/', '/.claude/skills/'],
   setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],
   testTimeout: 60000, // 60 seconds for inspector tests (needed for macOS)
+  maxWorkers: process.env.CI ? 1 : '50%', // Serialize on CI: 13 integration tests each spawn 2 child processes; concurrent spawning starves 2-vCPU runners past the 30s boot timeout
   collectCoverageFrom: [
     'src/**/*.{js,ts}',
     '!src/**/*.d.ts',


### PR DESCRIPTION
## Summary

- **PR #83** (trivial 27-line metrics change) failed CI twice with the same boot-race signature on **different integration test files and ports each run** — a classic flake, not a regression
- Root cause: 13 integration tests each spawn an MCP server + mcp-remote process pair; with no `maxWorkers` cap, Jest runs multiple suites concurrently on the 2-vCPU GitHub Actions runner
- Fix: add `maxWorkers: process.env.CI ? 1 : '50%'` to `jest.config.js` — GitHub Actions injects `CI=true` automatically, so CI serializes test files while local dev stays parallel

## Root cause analysis

Each integration test file in `test/integration/` calls `MCPClient.start()` which:
1. Spawns `node dist/index.js <port>` (MCP server)
2. Polls TCP connect every 300 ms for up to 30 s (`waitForServer`)
3. Spawns `npx mcp-remote http://localhost:<port>/mcp`

With N Jest workers on a 2-vCPU runner, N server+mcp-remote process pairs start simultaneously. Under CPU contention, some Node.js processes can't complete event-loop initialization within the 30-second budget. The failing file rotates between runs because the race outcome depends on OS scheduler timing — not a bug in any specific test.

Secondary note: `mcp-client.ts` has no `exit` event handler on the server process. A silent server crash (e.g., port conflict) goes undetected — the test just polls until timeout. This doesn't change with this fix but is worth a future follow-up.

## Evidence

- Run attempt 1 (2026-04-18 20:03Z): `test/integration/search-multiword.test.ts` port 38540
- Run attempt 2 (2026-04-18 20:34Z): `test/integration/meteoswiss-search.test.ts` port 35392
- Both: `Server failed to start in time (100 attempts on port NNNNN)` at `MCPClient.waitForServer` (mcp-client.ts:73)
- https://github.com/eins78/meteoswiss-llm-tools/actions/runs/24612776859/attempts/2

## Change

`packages/meteoswiss-mcp/jest.config.js` — one line:

```js
maxWorkers: process.env.CI ? 1 : '50%',
```

## Why not alternatives

| Option | Verdict |
|--------|---------|
| Increase timeout | Bandaid — doesn't fix CPU starvation root cause |
| Smarter readiness check | Orthogonal — TCP probe isn't the problem |
| Separate jest projects | Complex with same outcome for this suite size |
| `maxWorkers: 1` globally | Works but unnecessarily slow locally |

## Verification

- `pnpm run fix && pnpm run ci` passes locally (excluding the pre-existing macOS `port-mapping.test.ts` flake noted in project memory)
- Tests run 3× locally — stable 19/20 suites passing each time
- CI run on this PR is the definitive verification — both `Run tests` and `Run integration tests` steps should stay green

## Changesets

None — test-infra fix, no user-visible behavior change (per CLAUDE.md conventions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
