### PR TITLE
I: Version meteoswiss-mcp v2.3.1 + fix js-yaml override

### DIFF
--- a/.changeset/build-info-metric.md
+++ b/.changeset/build-info-metric.md
@@ -1,5 +1,0 @@
----
-"meteoswiss-mcp": patch
----
-
-Expose `meteoswiss_mcp_build_info{version, node_version}` Prometheus gauge for version observability. Enables the Grafana dashboard to show the deployed version of each environment (TEST and PROD) at a glance without querying MCP endpoints.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "path-to-regexp@>=8.0.0 <8.4.0": "8.4.2",
       "qs@<6.14.2": "6.15.1",
       "diff@>=4.0.0 <4.0.4": "9.0.0",
-      "js-yaml@<3.14.2": "4.1.1",
+      "js-yaml@<3.14.2": "3.14.2",
       "mcp-remote>path-to-regexp": "8.4.2",
       "eslint-plugin-tsdoc>@typescript-eslint/utils": "8.58.2",
       "hono": ">=4.12.14",

--- a/packages/meteoswiss-mcp/CHANGELOG.md
+++ b/packages/meteoswiss-mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # meteoswiss-mcp
 
+## 2.3.1
+
+### Patch Changes
+
+- fa7ab7b: Expose `meteoswiss_mcp_build_info{version, node_version}` Prometheus gauge for version observability. Enables the Grafana dashboard to show the deployed version of each environment (TEST and PROD) at a glance without querying MCP endpoints.
+
 ## 2.3.0
 
 ### Patch Changes

--- a/packages/meteoswiss-mcp/package.json
+++ b/packages/meteoswiss-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meteoswiss-mcp",
   "mcpName": "io.github.eins78/meteoswiss-mcp",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "MCP server for MeteoSwiss weather data — forecasts, real-time measurements, stations, pollen.",
   "license": "CC0-1.0",
   "author": "Max F. Albrecht <1@178.is>",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   path-to-regexp@>=8.0.0 <8.4.0: 8.4.2
   qs@<6.14.2: 6.15.1
   diff@>=4.0.0 <4.0.4: 9.0.0
-  js-yaml@<3.14.2: 4.1.1
+  js-yaml@<3.14.2: 3.14.2
   mcp-remote>path-to-regexp: 8.4.2
   eslint-plugin-tsdoc>@typescript-eslint/utils: 8.58.2
   hono: '>=4.12.14'
@@ -1701,6 +1701,9 @@ packages:
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2206,6 +2209,11 @@ packages:
   espree@11.2.0:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
@@ -2774,6 +2782,10 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -3555,6 +3567,9 @@ packages:
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -4511,7 +4526,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 4.1.1
+      js-yaml: 3.14.2
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -5661,6 +5676,10 @@ snapshots:
 
   arg@4.1.3: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -6188,6 +6207,8 @@ snapshots:
       acorn: 8.16.0
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 5.0.1
+
+  esprima@4.0.1: {}
 
   esquery@1.7.0:
     dependencies:
@@ -7003,6 +7024,11 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -7642,7 +7668,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 4.1.1
+      js-yaml: 3.14.2
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -7859,6 +7885,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  sprintf-js@1.0.3: {}
 
   stack-utils@2.0.6:
     dependencies:


### PR DESCRIPTION
This PR was manually created because the automated `version-packages.yml` workflow is broken:

[Workflow failure](https://github.com/eins78/meteoswiss-llm-tools/actions/runs/24614130388)

**Root cause:** The pnpm override `"js-yaml@<3.14.2": "4.1.1"` force-bumped `js-yaml` to 4.1.1 globally, which removed the `safeLoad` API that `read-yaml-file@1.1.0` (a transitive dep of `@changesets/cli`) still relies on. Error:

> `Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.`

**Fix included in this PR:** override now pins to `3.14.2` — the CVE-fixed 3.x version that still exposes `safeLoad`. This keeps both the security advisory addressed AND the `@changesets/cli` path working.

## Releases

### meteoswiss-mcp 2.3.0 → 2.3.1 (patch)

- Expose `meteoswiss_mcp_build_info{version, node_version}` Prometheus gauge for version observability. Enables the Grafana dashboard to show the deployed version of each environment (TEST and PROD) at a glance without querying MCP endpoints.

---

Merge this PR to trigger `release.yml` which publishes + deploys 2.3.1 to PROD.
