### PR TITLE
meteoswiss-mcp: restore ChatGPT fetch/search compat + regression test suite

### DIFF
--- a/.changeset/chatgpt-fetch-compat.md
+++ b/.changeset/chatgpt-fetch-compat.md
@@ -1,0 +1,5 @@
+---
+"meteoswiss-mcp": patch
+---
+
+Restore ChatGPT Deep Research / Connectors compatibility for the `fetch` tool. The v2.3.1 release renamed the `fetch` argument from `id` to `url`, which broke the canonical contract that ChatGPT (and the OpenAI Responses API Deep Research models) expects. This release renames it back to `id`, adds the canonical `text` and top-level `url` fields to the `fetch` response, keeps `content` as a back-compat alias of `text`, and adds an integration test suite + tool-manifest snapshot to prevent the regression from recurring. See `docs/plans/2026-04-19-chatgpt-fetch-compat.md` for the full investigation and references.

--- a/docs/plans/2026-04-19-chatgpt-fetch-compat.md
+++ b/docs/plans/2026-04-19-chatgpt-fetch-compat.md
@@ -1,6 +1,6 @@
 # Plan: ChatGPT Deep Research `fetch`/`search` Compatibility
 
-> Restore canonical ChatGPT Deep Research MCP tool contract for `fetch` (param: `id`, response field: `text`) and lock it in with a regression test suite + serialized tool-manifest snapshot.
+> Restore canonical ChatGPT Deep Research MCP tool contract for `fetch` (param: `id`, response field: `text`) and lock it in with a regression test suite + serialized tool-manifest snapshot. Document the broader ChatGPT-MCP integration landscape so the next engineer doesn't have to re-do the research.
 
 ## Status
 
@@ -8,155 +8,544 @@
 - **Type:** bug
 - **Sprint:**
 
-## Problem
+## TL;DR
 
-ChatGPT Deep Research consumes MCP servers via two well-known tools — `search` and `fetch` — with a tightly defined input/output contract. The current `meteoswiss-mcp` implementation diverges from that contract on `fetch`:
+`packages/meteoswiss-mcp` v2.3.1 (released 2026-04-18) is incompatible with the **ChatGPT Deep Research / Connectors** MCP contract on the `fetch` tool. Specifically:
 
-| Field | ChatGPT spec (canonical) | `meteoswiss-mcp` today | Status |
+| Field | ChatGPT spec (canonical) | `meteoswiss-mcp` v2.3.1 | Status |
 |---|---|---|---|
-| `fetch` input arg | `id: string` | `url: string` | ❌ incompatible |
-| `fetch` response payload field for body | `text` | `content` | ❌ incompatible |
-| `fetch` response payload structure | `{id, title, text, url, metadata}` | `{id, title, content, format, metadata}` | ❌ incompatible |
-| `search` input arg | `query: string` | `query: string` (+ optional extras) | ✅ compatible |
-| `search` response payload | `{results: [{id, title, url, text?}]}` | `{totalResults, page, pageSize, results: [{id, title, url, description, …}]}` | ✅ tolerated (extra fields OK; ChatGPT looks for `results[]` with `id`/`title`/`url`) |
-| MCP envelope | `{content: [{type: "text", text: <JSON>}]}` | same | ✅ |
+| `fetch` input arg name | `id: string` | `url: string` | ❌ incompatible |
+| `fetch` body field name | `text` | `content` | ❌ incompatible |
+| `fetch` output keys | `{id, title, text, url, metadata}` | `{id, title, content, format, metadata}` | ❌ incompatible |
+| `search` input arg | `query: string` | `query: string` (+ optional `language`, `contentType`, `page`, `pageSize`, `sort`) | ✅ compatible (extras tolerated) |
+| `search` output | `{results: [{id, title, text?, url}]}` | `{totalResults, page, pageSize, results: [{id, title, url, description, …}]}` | ✅ tolerated (wrapper extras OK; ChatGPT looks for `results[]` containing `id`/`title`/`url`) |
+| MCP envelope | `{content: [{type: "text", text: "<JSON>"}]}` | same | ✅ |
 
-### Origin of the regression
+The fix is a minimal rename (`url` → `id`), a response-shape addition (`text` field), and a regression test suite + tool-manifest snapshot to prevent the next "innocent" rename from re-breaking it.
 
-`packages/meteoswiss-mcp/src/schemas/meteoswiss-fetch.ts` was created with `id` as the param name (commit d6b1c62, original monorepo introduction). On 2026-04-18 commit **de9c937** ("B: Fix international city blocklist, NOTASTATION geocoding guard, fetch url param") explicitly renamed `id → url` with the message *"Revert fetch schema param id → url (rc.3 rename was unintentional)"*. Git history disagrees: `id` has been the param name since the schema file was first added, and was kept through rc.3. The de9c937 reversion is therefore itself the regression — and it landed in `2.3.1` (the version currently in production).
+---
 
-There is no integration regression test that asserts ChatGPT-shaped calls succeed, so the rename slipped through CI. The existing `test/integration/meteoswiss-fetch.test.ts:34` actively *enforces* the broken shape (`url` as the required field).
+## 1. ChatGPT side: how MCP integrates today
 
-### Authoritative sources (cited in the test suite)
+ChatGPT exposes **three distinct integration modes**, each with different MCP-server requirements. The meteoswiss server is currently used in mode (a).
 
-- **OpenAI Cookbook — official Deep Research MCP example:**
-  - <https://github.com/openai/openai-cookbook/blob/main/examples/deep_research_api/how_to_build_a_deep_research_mcp_server/main.py>
-  - Verbatim: `async def fetch(id: str) -> Dict[str, Any]:` returning `{"id": …, "title": …, "text": file_content, "url": …, "metadata": …}`
-- **Vercel Labs reference TypeScript implementation:**
-  - <https://github.com/vercel-labs/deep-research-server/blob/main/app/mcp/route.ts>
-  - Verbatim Zod schema: `{ id: z.string().describe("Document ID from search results") }`, returning `{id, title, text, url, metadata}`
-- **OpenAI developer docs — MCP integration overview:** <https://developers.openai.com/api/docs/mcp>
-- **OpenAI Deep Research API guide:** <https://platform.openai.com/docs/guides/deep-research>
-- **MCP TypeScript SDK** (`@modelcontextprotocol/sdk` 1.28+): tool registration with `server.tool(name, description, schema, handler)` is unchanged in 1.28.0; the protocol envelope (`content: [{type: 'text', text: ...}]`) is stable. No SDK rename motivated the de9c937 reversion.
+### (a) Standard Custom Connector / Deep Research / "Company knowledge"
 
-## Current state
+This is the *default* path for any user (Free/Plus/Pro/Enterprise) connecting an MCP server to ChatGPT — and the only path used by the Deep Research tools (`o3-deep-research-2025-06-26` and successors).
 
-- `meteoswiss-mcp` v2.3.1 deployed at <https://meteoswiss-mcp.ars.is/mcp>.
-- `fetch` tool refuses ChatGPT-shaped calls: `tools/call {name: "fetch", arguments: {id: "<url>"}}` → Zod validation error (unknown property `id`, missing required `url`).
-- Even when called with `{url: …}`, response body has `text` field absent → ChatGPT parses a record with no body content.
-- `search` works as-is for ChatGPT; the wrapping object adds harmless extra keys.
+**Required:**
 
-## Target state
+- The server **MUST** expose exactly two tools, named `search` and `fetch`. (Sources cited below all say "MUST"; a community Medium post confirms ChatGPT silently rejects servers that don't.)
+- The tools must follow the canonical input/output schemas in §2.
+- Other tools may also be registered; ChatGPT will simply ignore them.
+- Plus/Pro users in standard mode are *limited to read-only connectors* — `search`/`fetch` only, no destructive writes.
 
-1. **`fetch` accepts `id` as the canonical param name** (matches OpenAI cookbook + Vercel reference).
-2. **`fetch` accepts `url` as a deprecated alias** for one minor version, so any custom client that started relying on the de9c937-era shape doesn't immediately break. Schema rejects the call only if *neither* is provided. Aliasing is implemented with a Zod `preprocess` step — at the schema level the canonical name remains `id`.
-3. **`fetch` response includes a `text` field** with the body content (in addition to the existing `content` field for one minor version, for the same back-compat reason).
-4. A **dedicated compat integration test suite** asserts:
-   - `tools/list` exposes a `fetch` tool whose JSON Schema declares `id` as a required string.
-   - Calling `fetch` with `{id: "<url>"}` succeeds and the parsed text payload contains all five canonical fields (`id`, `title`, `text`, `url`, `metadata`).
-   - Calling `fetch` with `{url: "<url>"}` (legacy) still succeeds.
-   - Calling `search` with `{query: "<…>"}` returns a payload whose parsed JSON contains a `results` array of objects with `id`, `title`, `url`.
-   - The MCP envelope (`content[0].type === "text"`, `content[0].text` is parseable JSON) holds.
-5. A **tool-manifest snapshot** (`test/__snapshots__/chatgpt-compat.test.ts.snap`) captures the serialized `tools/list` output for `search` and `fetch` (name, description, `inputSchema.properties.*`, `inputSchema.required`). Future renames or rearrangements break the snapshot, forcing an explicit acknowledgement.
-6. Existing `test/integration/meteoswiss-fetch.test.ts` is updated to use `id` (or both, to demonstrate the alias) so it stops enforcing the broken shape.
+**Quote (OpenAI cookbook README):**
+> The Deep Research agent relies specifically on Search and Fetch tools. Search should look through your object store for a set of specfic, top-k IDs. Fetch, is a tool that takes objectIds as arguments and pulls back the relevant resources.
 
-## Design
+Source: <https://raw.githubusercontent.com/openai/openai-cookbook/main/examples/deep_research_api/how_to_build_a_deep_research_mcp_server/README.md> (commit 012c79d3, 2025-06-26)
 
-### Schema change (`src/schemas/meteoswiss-fetch.ts`)
+**Quote (OpenAI Deep Research guide):**
+> The model is optimized to call data sources exposed through this interface and doesn't support tool calls or MCP servers that don't implement this interface.
 
-```ts
-// Canonical name is `id` (matches OpenAI cookbook/Vercel reference).
-// Accept `url` as a deprecated alias for back-compat with v2.3.1 callers.
-export const fetchMeteoSwissContentSchema = z
-  .preprocess((value) => {
-    if (value && typeof value === 'object' && !Array.isArray(value)) {
-      const v = value as Record<string, unknown>;
-      if (v.id === undefined && typeof v.url === 'string') {
-        return { ...v, id: v.url };
-      }
-    }
-    return value;
-  }, z.object({
-    id: z.string().min(1, { /* … */ }).describe('…'),
-    format: z.enum(['markdown', 'text']).optional().default('markdown'),
-    includeMetadata: z.boolean().optional().default(true),
-  }));
+Source: <https://developers.openai.com/api/docs/guides/deep-research> (accessed 2026-04-19)
+
+### (b) Apps SDK / Developer Mode (full MCP)
+
+A beta channel (launched 2026-03-13 per multiple secondary sources) for Plus/Pro subscribers in Developer Mode that allows arbitrary tool names. Not relevant to meteoswiss today, but worth knowing about for forward planning.
+
+**Differences from (a):**
+
+- Arbitrary tool names allowed (`list_tasks`, `update_task`, etc.).
+- Tool annotations are **mandatory**: `readOnlyHint`, `openWorldHint`, `destructiveHint`.
+- For UI rendering, resources must declare `"mimeType": "text/html;profile=mcp-app"`.
+- Plus/Pro users are **still capped at read-only** connectors even in Developer Mode (writes require Enterprise admin approval).
+
+Source: <https://developers.openai.com/apps-sdk/build/mcp-server> (accessed 2026-04-19)
+Secondary: <https://medium.com/@alexeylark/chatgpt-custom-mcp-connectors-with-developer-mode-d791fde17d25>, <https://gist.github.com/ruvnet/7b6843c457822cbcf42fc4aa635eadbb>
+
+### (c) Responses API direct MCP integration (`type: "mcp"` in tools array)
+
+Used by API consumers (not the ChatGPT chat UI) calling the Responses API with an MCP `server_url`. Same Deep Research `search`/`fetch` contract applies when used with `o3-deep-research-*` models. With other models, arbitrary tool names work (regular function-calling).
+
+**Quote (cookbook example):**
+```python
+tools=[
+    {"type": "web_search_preview"},
+    {
+        "type": "mcp",
+        "server_label": "internal_file_lookup",
+        "server_url": "http://0.0.0.0:8000/sse/",
+        "require_approval": "never",
+    },
+]
 ```
 
-Rationale: `preprocess` keeps the JSON Schema seen by ChatGPT clean (only `id` shows up in `tools/list`), while still accepting legacy `url` calls at runtime. The runtime type stays `{id: string, format: …, includeMetadata: …}`.
+`require_approval: "never"` is required for read-only Deep Research operations — otherwise every tool call interrupts the agent for approval.
 
-### Response shape change (`src/data/meteoswiss-content-data.ts`)
+### Choosing between modes
+
+| Mode | When |
+|---|---|
+| (a) Standard Custom Connector | meteoswiss today — public read-only connector, free for all ChatGPT tiers, Deep Research compatible. |
+| (b) Apps SDK / Developer Mode | If we wanted custom tools (`meteoswissLocalForecast` etc.) callable from ChatGPT chat UI directly. Requires UI design + per-user opt-in. Out of scope. |
+| (c) Responses API direct | For programmatic Deep Research integration. Same `search`/`fetch` contract, so this is fixed simultaneously with (a). |
+
+We commit to (a) for now. The fix in this plan is also the right baseline for (c). If we ever pursue (b), this plan's tests still apply (they assert canonical `search`/`fetch` shape — Apps SDK *is allowed to* register additional tools alongside, so the contract is forward-compatible).
+
+---
+
+## 2. Canonical contract (mode a) — verbatim from references
+
+Two independent reference implementations agree on the contract; we cite both verbatim.
+
+### 2.1 OpenAI Cookbook — Python (`fastmcp`)
+
+Source: <https://github.com/openai/openai-cookbook/blob/main/examples/deep_research_api/how_to_build_a_deep_research_mcp_server/main.py> (commit 012c79d3, 2025-06-26)
+
+```python
+@mcp.tool()
+async def search(query: str) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Search for documents using OpenAI Vector Store search.
+    ...
+    Returns:
+        Dictionary with 'results' key containing list of matching documents.
+        Each result includes id, title, text snippet, and optional URL.
+    """
+    ...
+    result = {
+        "id": item_id,
+        "title": item_filename,
+        "text": text_snippet,
+        "url": f"https://platform.openai.com/storage/files/{item_id}",
+    }
+    ...
+    return {"results": results}
+
+@mcp.tool()
+async def fetch(id: str) -> Dict[str, Any]:
+    """
+    Retrieve complete document content by ID for detailed analysis and citation.
+    ...
+    Returns:
+        Complete document with id, title, full text content, optional URL, and metadata
+    """
+    ...
+    result = {
+        "id": id,
+        "title": filename,
+        "text": file_content,
+        "url": f"https://platform.openai.com/storage/files/{id}",
+        "metadata": None,
+    }
+    if hasattr(file_info, "attributes") and file_info.attributes:
+        result["metadata"] = file_info.attributes
+    return result
+```
+
+### 2.2 Vercel Labs — TypeScript (`mcp-handler` + zod)
+
+Source: <https://raw.githubusercontent.com/vercel-labs/deep-research-server/main/app/mcp/route.ts>
 
 ```ts
-export interface ContentResponse {
-  id: string;
-  title?: string;
-  text: string;            // canonical (ChatGPT)
-  /** @deprecated kept for back-compat with v2.3.1 — will be removed in 3.0 */
-  content: string;
-  format: 'markdown' | 'text';
-  url?: string;            // canonical (ChatGPT) — equals id when id is a URL
-  metadata?: { … };
+server.tool(
+  "search",
+  "Search for documents using semantic search. ...",
+  { query: z.string().describe("Search query string. ...") },
+  { title: 'Search documents', readOnlyHint: true },
+  async ({ query }) => {
+    ...
+    return { content: [{ type: "text", text: JSON.stringify({ results }, null, 2) }] };
+  }
+);
+
+server.tool(
+  "fetch",
+  "Retrieve complete document content by ID for detailed analysis and citation. ...",
+  { id: z.string().describe("Document ID from search results (e.g., doc_1, doc_2, etc.)") },
+  { title: 'Fetch document', readOnlyHint: true },
+  async ({ id }) => {
+    ...
+    const result = {
+      id: document.id,
+      title: document.title,
+      text: document.text,
+      url: document.url,
+      metadata: { source: "sample_data", created_at: "...", updated_at: "..." },
+    };
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  }
+);
+```
+
+### 2.3 Synthesised contract
+
+| Tool | Input | Output payload (JSON-stringified into `content[0].text`) |
+|---|---|---|
+| `search` | `{ query: string }` | `{ results: Array<{ id: string; title: string; text?: string; url: string }> }` |
+| `fetch` | `{ id: string }` | `{ id: string; title: string; text: string; url: string; metadata?: object \| null }` |
+
+### 2.4 MCP envelope
+
+Both references wrap the JSON payload in the standard MCP `tools/call` result envelope:
+
+```json
+{
+  "content": [
+    { "type": "text", "text": "<JSON.stringify(payload)>" }
+  ]
 }
 ```
 
-`processHtmlContent` populates both `text` and `content` with the same string for one minor version. `url` is set to the resolved full URL (which is also `id` for our server, since our IDs *are* URLs).
+The MCP 2025-11-25 spec also allows `structuredContent` (typed JSON object alongside the text). ChatGPT today reads only `content[0].text`; emitting `structuredContent` is harmless but not required.
 
-### Server registration (`src/server.ts`)
+> **Quote (MCP spec 2025-11-25, Tools page):**
+> *"For backwards compatibility, a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block."*
 
-No change needed beyond the schema/response updates. The `params.url` reference at line 114 becomes `params.id` (post-preprocess) — and the log line + handler call switch accordingly.
+Source: <https://modelcontextprotocol.io/specification/2025-11-25/server/tools>
 
-### Tests
+---
 
-- **New file:** `packages/meteoswiss-mcp/test/integration/chatgpt-compat.test.ts`
-  - Boots the server via the existing `MCPClient`.
-  - Asserts `tools/list` has `search` + `fetch` with the spec'd schemas.
-  - Asserts `fetch` with `{id: …}` happy path.
-  - Asserts `fetch` with `{url: …}` legacy path.
-  - Asserts `search` happy path.
-  - Asserts MCP envelope shape (`content[0].type === 'text'`, JSON-parseable text).
-  - Snapshot-asserts the manifest entries for `search` + `fetch`.
-- **Updated file:** `packages/meteoswiss-mcp/test/integration/meteoswiss-fetch.test.ts`
-  - Switch the schema-shape assertion at L31–L52 from `url` (required) to `id` (required).
-  - Switch the call-tool inputs from `{url: …}` to `{id: …}`.
-  - Replace `result.content` body assertions with `result.text` (keep one assertion that `result.content === result.text` to lock in the back-compat alias).
+## 3. Transport, auth, protocol revision, error semantics
 
-### Snapshot policy
+### Transport
 
-The snapshot lives at `test/__snapshots__/chatgpt-compat.test.ts.snap`. Reviewers must explicitly approve any change to it. The snapshot includes:
+| Transport | Status for ChatGPT |
+|---|---|
+| Streamable HTTP (`/mcp` endpoint, POST/GET/DELETE) | ✅ Supported (used today by meteoswiss). |
+| SSE (`/sse/` endpoint) | ✅ Supported (used by OpenAI cookbook example). |
+| stdio | ❌ Not for remote connectors. Used only when ChatGPT is bridged via `mcp-remote`. |
+| WebSocket | ❌ Not standard for ChatGPT. |
 
-- `name`
-- `description`
-- `inputSchema.type`
-- `inputSchema.properties[*].type` and `properties[*].description`
-- `inputSchema.required` (sorted)
+OpenAI Responses API:
+> *"The Responses API works with remote MCP servers supporting either the Streamable HTTP or the HTTP/SSE transport protocols."*
 
-It **excludes** generated/volatile fields like JSON-schema `$id`, ordering inside non-required arrays, and zod-generated metadata fields, so it's stable across SDK patch bumps.
+Source: <https://developers.openai.com/api/docs/guides/tools-connectors-mcp>
 
-## Test plan
+### MCP protocol revision
 
-1. New `chatgpt-compat.test.ts` passes (new ChatGPT-shaped calls succeed; snapshot matches).
-2. Updated `meteoswiss-fetch.test.ts` passes with `id` as the canonical param.
-3. Other integration tests continue to pass (no regression to OGD tools).
-4. `pnpm --filter meteoswiss-mcp run ci` is green (lint, build, test).
-5. Manual smoke: connect ChatGPT custom MCP connector to a local server (`pnpm dev`) and verify a Deep Research run completes end-to-end. *Note: not gated in CI; documented in PR body.*
+The TS SDK currently shipped in our `package.json` is `@modelcontextprotocol/sdk@^1.28.0` (latest 1.x at time of writing is 1.29.0, released 2026-03-30).
 
-## Out of scope
+- The 2025-11-25 protocol revision is supported from SDK **1.24.0** onward.
+- Our integration test client (`packages/meteoswiss-mcp/test/integration/mcp-client.ts:172`) handshakes with `protocolVersion: '2025-11-25'`, so we are speaking the latest stable revision.
+- ChatGPT/OpenAI tutorials reference `2025-06-18` as the negotiation target (Apps SDK Developer Mode tutorial, gist `ruvnet/7b6843c457822cbcf42fc4aa635eadbb`); MCP servers are required to support the negotiated version, and our SDK transparently negotiates down to 2025-06-18 if a client requests it.
 
-- Renaming any of the OGD tools (`meteoswissLocalForecast`, etc.).
-- Changing the search response shape — the wrapper `{totalResults, page, pageSize, results}` is tolerated by ChatGPT and used by other clients; a breaking change there would require a major bump.
-- Removing the `url` alias and the `content` legacy field — that's a 3.0 task tracked separately.
+### MCP TS SDK changelog scan (1.21 → 1.29)
 
-## Rollout
+I scanned every release between 1.21 and 1.29 (`https://api.github.com/repos/modelcontextprotocol/typescript-sdk/releases`). Relevant findings:
 
-Single PR from `feature/chatgpt-fetch-compat` → `main`. Patch-level changeset (`meteoswiss-mcp: patch`) since the change is bug-fix-only and additive at the schema level (legacy `url` and `content` still work). Post-merge: standard Changesets bot release flow.
+- **1.23.0 (2025-11-25):** Zod v4 support added with v3.25+ backwards compat (PR #1040).
+- **1.24.0 (2025-12-02):** Spec bump to **2025-11-25** (PR #1166). `registerTool` signature update for typed `ToolCallback` (PR #1188). Hanging stdio servers fix (PR #1200).
+- **1.25.0 (2025-12-15):** Zod v4 schema description extraction fix (PR #1296). `outputSchema` updates supported (PR #1048).
+- **1.26.0 (2026-02-04):** GHSA-345p-7cg4-v4c7 security advisory: shared server/transport instances could leak cross-client response data. Fixed.
+- **1.27.0 (2026-02-16):** Streaming methods for elicitation/sampling.
+- **1.28.0 (2026-03-25, our version):** `inputSchema` validation tightened — *"reject plain JSON Schema objects passed as inputSchema"* (PR #1596). RFC 8252 loopback port relaxation in OAuth (PR #1738).
+- **1.29.0 (2026-03-30):** Mostly auth fixes; backport of `null` (infinite) requested-TTL disallow.
+- **2.0.0-alpha (2026-04-01):** Switches to Standard Schema spec (Zod v4, Valibot, ArkType, ...). **Unknown/disabled tool calls now return JSON-RPC `-32602` instead of `CallToolResult` with `isError: true`** — relevant breaking change *if/when* we upgrade.
 
-## References
+**Conclusion:** No SDK release in this range renamed a tool-arg field, deprecated the `id` parameter name, or otherwise motivated the rc.3-era `id → url` rename. The rename was not SDK-driven.
 
-- OpenAI Cookbook MCP server example: <https://github.com/openai/openai-cookbook/blob/main/examples/deep_research_api/how_to_build_a_deep_research_mcp_server/main.py>
-- Vercel deep-research-server: <https://github.com/vercel-labs/deep-research-server/blob/main/app/mcp/route.ts>
-- OpenAI Developer docs (MCP): <https://developers.openai.com/api/docs/mcp>
-- OpenAI Deep Research API: <https://platform.openai.com/docs/guides/deep-research>
-- MCP TypeScript SDK: <https://github.com/modelcontextprotocol/typescript-sdk>
-- Regressing commit: `de9c937` (B: Fix international city blocklist, NOTASTATION geocoding guard, fetch url param)
-- Original `id` introduction: `d6b1c62` (Prod promotion: monorepo, rename, docs overhaul)
+### Auth
+
+Public read-only servers (us): no auth required. ChatGPT connects as anonymous MCP client. The OpenAI Apps SDK and Connectors docs **recommend** OAuth + dynamic client registration for any server that touches user data — but for a read-only public weather server, no-auth is the documented happy path.
+
+> *"We recommend using OAuth and dynamic client registration."* — <https://developers.openai.com/api/docs/mcp>
+> *"`require_approval: never`"* — required for Deep Research read-only flows so the agent doesn't pause on every tool call.
+
+### Error semantics
+
+MCP 2025-11-25 distinguishes:
+
+1. **Protocol errors** — JSON-RPC `error` with codes like `-32602` (Invalid params), `-32601` (Method not found). Returned for unknown tools, malformed `tools/call` requests, etc.
+2. **Tool execution errors** — `result.isError: true` with `content[]` containing a human-readable message.
+
+The current meteoswiss `fetch` returns tool-execution errors (`isError: true` + text content) for fetch failures. That matches the spec — **don't change error handling in this PR**.
+
+### Response size
+
+No hard limit documented for ChatGPT. The OpenAI reference `mcp-fetch` server (`modelcontextprotocol/servers/src/fetch`) implements pagination via `start_index` + `max_length` because LLMs choke on long content; that pattern is for non-Deep-Research use though. For Deep Research, the cookbook returns full file content unchunked. Our pages are small (typical MeteoSwiss article is a few hundred KB of HTML, which simplifies to a few thousand chars of markdown), so we're safe. **Out of scope here.**
+
+---
+
+## 4. Reference servers — what they do (and why they're different)
+
+| Server | Tool name | Input arg | For ChatGPT? |
+|---|---|---|---|
+| OpenAI cookbook `deep_research_api` | `fetch` | `id` | ✅ Yes — canonical. |
+| Vercel Labs `deep-research-server` | `fetch` | `id` | ✅ Yes — canonical TS reference. |
+| `modelcontextprotocol/servers/src/fetch` (Python) | `fetch` | `url` (a `Fetch` Pydantic model with `url: AnyUrl`) | ❌ No. Generic web-scraper, not Deep-Research-shaped. |
+
+The third one is what the user's de9c937 reversion was probably modelling. But the generic `fetch` server is a *different* tool — it's not designed to be paired with `search` and isn't on the ChatGPT compat path. Source: <https://raw.githubusercontent.com/modelcontextprotocol/servers/main/src/fetch/src/mcp_server_fetch/server.py>.
+
+> **Takeaway:** "MCP fetch server" is an overloaded name. There's the **generic web fetcher** (`url`) and the **Deep Research record fetcher** (`id`). Meteoswiss is the latter.
+
+---
+
+## 5. Our current declaration
+
+Files of record (paths relative to `packages/meteoswiss-mcp/`):
+
+- `src/schemas/meteoswiss-fetch.ts` — Zod schema for the `fetch` tool params.
+- `src/schemas/meteoswiss-search.ts` — Zod schema for the `search` tool params.
+- `src/tools/meteoswiss-fetch.ts` — Handler wrapper.
+- `src/tools/meteoswiss-search.ts` — Handler wrapper.
+- `src/data/meteoswiss-content-data.ts` — Data layer for fetch (returns `ContentResponse`).
+- `src/data/meteoswiss-search-data.ts` — Data layer for search (returns `SearchResults`).
+- `src/server.ts` — Calls `server.tool('search', …)` and `server.tool('fetch', …)`.
+
+### Current `fetch` shape (v2.3.1)
+
+**Input schema** (`src/schemas/meteoswiss-fetch.ts`):
+```ts
+z.object({
+  url: z.string().min(1).describe('Full URL of a MeteoSwiss page to fetch...'),
+  format: z.enum(['markdown', 'text']).optional().default('markdown'),
+  includeMetadata: z.boolean().optional().default(true),
+})
+```
+
+**Output payload** (`ContentResponse` in `src/data/meteoswiss-content-data.ts`):
+```ts
+{
+  id: string;        // populated as the resolved full URL
+  title?: string;
+  content: string;   // body text — wrong field name for ChatGPT
+  format: 'markdown' | 'text';
+  metadata?: { url, language?, lastModified?, contentType?, keywords?, description? };
+}
+```
+
+### Current `search` shape (v2.3.1)
+
+**Input:**
+```ts
+z.object({
+  query: z.string().min(1).describe('The search query string'),
+  language: z.enum(['de','fr','it','en']).optional().default('de'),
+  contentType: z.enum(['content','press-release','blog-article','publication']).optional(),
+  page: z.number().int().positive().optional().default(1),
+  pageSize: z.number().int().positive().max(100).optional().default(12),
+  sort: z.enum(['relevance','date-desc','date-asc']).optional().default('relevance'),
+})
+```
+
+**Output payload** (`SearchResults`):
+```ts
+{
+  totalResults: number;
+  page: number;
+  pageSize: number;
+  results: Array<{
+    id: string;          // full URL — matches ChatGPT spec
+    title: string;       // matches
+    url: string;         // matches
+    description?: string;
+    contentType?: string;
+    lastModified?: string;
+    path?: string;
+    lead?: string;
+    publicationDate?: string;
+  }>;
+}
+```
+
+### Diff vs canonical
+
+1. **`fetch.input.id` is missing** (we have `url` instead). **Incompatible.**
+2. **`fetch.output.text` is missing** (we have `content` instead). **Incompatible.**
+3. **`fetch.output.url` is missing at the top level** (only inside `metadata`). **Incompatible** with the strict spec, though tolerated in practice if `id` is a URL.
+4. `search.input.query` ✓.
+5. `search.output.results[*]` has `id`, `title`, `url` ✓ — extra fields ignored.
+6. MCP envelope (`content[0].type === 'text'`, JSON-stringified body) ✓.
+
+### Origin of the regression
+
+```
+b1850b5 (2026-04-03)  B: Fix fetch tool description — id must be full URL from search
+de9c937 (2026-04-18)  B: Fix international city blocklist, NOTASTATION geocoding guard, fetch url param
+                          ↑↑↑ this commit reverted id → url in src/schemas/meteoswiss-fetch.ts
+```
+
+The de9c937 commit message claims *"Revert fetch schema param id → url (rc.3 rename was unintentional)"*. Git history says otherwise: `id` has been the param name since the very first commit that introduced this file (`d6b1c62` *"Prod promotion: monorepo, rename, docs overhaul"*). There was no rc.3 rename of `url → id`; the field was always `id`. The de9c937 reversion is therefore not actually a revert — it's a regression that landed in v2.3.1 and broke the ChatGPT happy path.
+
+The existing test `test/integration/meteoswiss-fetch.test.ts:34` *enforces* the broken `url` shape, so the regression slipped through CI. That test must be updated as part of the fix.
+
+---
+
+## 6. Target state
+
+### 6.1 Source changes (minimal)
+
+| File | Change |
+|---|---|
+| `src/schemas/meteoswiss-fetch.ts` | Rename input field `url` → `id`. Update description. No alias shim — see §6.2 for rationale. |
+| `src/data/meteoswiss-content-data.ts` | `ContentResponse` gains `text: string` (canonical) and top-level `url: string` (matches resolved page URL). `content` stays as a deprecated alias of `text` for one minor version so existing callers and snapshots aren't broken in this PR. Internal variables renamed `url → id` where they refer to the input, kept as `url` only for the resolved full URL inside the function. |
+| `src/tools/meteoswiss-fetch.ts` | `params.url` → `params.id` in the debug log line. |
+| `src/server.ts` | `params.url` → `params.id` in the request log line. Tool description text updated to refer to `id`. |
+| `test/integration/meteoswiss-fetch.test.ts` | Update the JSON-Schema shape assertion (`required: ['url']` → `required: ['id']`, etc.), update all `callTool('fetch', {url: …})` calls to use `{id: …}`, and add an assertion that `result.content === result.text` to lock in the alias. |
+
+No changes to `search` schema or response shape — they're already compatible.
+
+### 6.2 Why no `url` alias shim?
+
+The `url` field shape is **24 hours old in production** (v2.3.1 published 2026-04-18). The only operator deploying this server is the user (eins78). No third-party automation has had time to integrate against `url`. Adding a `z.preprocess` shim that accepts both `id` and `url` would:
+
+- Pollute `tools/list` (advertise both fields → ChatGPT might pick the wrong one).
+- Or hide `url` from `tools/list` but still accept it at runtime (mismatch between schema and reality, hard to test).
+- Add complexity for ~zero real callers.
+
+**Decision:** Pure rename. No alias.
+
+### 6.3 Why keep `content` as an alias of `text`?
+
+The existing test suite has *many* assertions on `result.content`. Renaming `content → text` *and* removing `content` in the same PR balloons the diff and risks breaking ancillary tests we haven't audited. The two-step path (add `text`, deprecate `content`, remove in 3.0) is cheaper and safer.
+
+### 6.4 New `text` + `url` at top level, not just in `metadata`
+
+ChatGPT reads:
+- `result.text` — the body content.
+- `result.url` — the canonical citation URL.
+
+Both should be at the top level of the JSON-stringified payload. The existing `metadata.url` is preserved (other clients may rely on it).
+
+---
+
+## 7. Test plan
+
+### 7.1 New file: `test/integration/chatgpt-compat.test.ts`
+
+A dedicated integration test suite that boots the server (via the existing `MCPClient` harness, with `USE_TEST_FIXTURES=true`) and asserts the canonical ChatGPT contract end-to-end:
+
+1. **`tools/list` exposes `search` and `fetch`** with the spec'd schemas.
+   - `fetch.inputSchema`: `properties.id.type === 'string'`, `required` contains `'id'`, does **not** contain `'url'`.
+   - `search.inputSchema`: `properties.query.type === 'string'`, `required` contains `'query'`.
+2. **`fetch` happy path** with `{id: "<full URL>"}` succeeds.
+   - Response `content[0].type === 'text'`.
+   - Parsed body has `id`, `title`, `text` (non-empty string), `url`, `metadata`.
+   - `text === content` (back-compat alias).
+3. **`fetch` rejects calls without `id`** — calling with `{}` returns either a JSON-RPC protocol error or `isError: true`. (Whichever the SDK does — assert at least one of them.)
+4. **`search` happy path** with `{query: "klima"}` succeeds.
+   - Parsed body has a `results` array.
+   - Every result has `id` (string), `title` (string), `url` (string).
+5. **MCP envelope holds** for both tools — `content[0].type === 'text'`, `content[0].text` is parseable JSON.
+6. **Snapshot assertion** — see §7.2.
+
+Each test cites the source-of-truth URL in a comment so future readers know why the assertion exists.
+
+### 7.2 Manifest snapshot
+
+`test/__snapshots__/chatgpt-compat.test.ts.snap` (Jest snapshot) captures a normalised version of the `tools/list` output for `search` and `fetch`:
+
+```jsonc
+{
+  "search": {
+    "name": "search",
+    "description": "<…>",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "query": { "type": "string", "description": "<…>" },
+        // … other properties (sorted)
+      },
+      "required": ["query"]   // sorted
+    }
+  },
+  "fetch": {
+    "name": "fetch",
+    "description": "<…>",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "description": "<…>" },
+        "format": { … },
+        "includeMetadata": { … }
+      },
+      "required": ["id"]
+    }
+  }
+}
+```
+
+The serialiser:
+- Sorts `required` arrays.
+- Sorts object keys alphabetically.
+- Strips zod-internal/`additionalProperties: false` noise that may shift between SDK patches.
+- Includes the `description` field (so renaming/rewording the description triggers a snapshot diff and forces the reviewer to acknowledge the change).
+
+### 7.3 Updated existing tests
+
+`test/integration/meteoswiss-fetch.test.ts`:
+- `properties.url` → `properties.id`.
+- `required: ['url']` → `required: ['id']`.
+- All `callTool('fetch', {url: …})` → `callTool('fetch', {id: …})`.
+- Add `expect(result.text).toBe(result.content)` (alias guard).
+- Existing assertions on `result.content` stay (they validate the alias still works).
+
+### 7.4 Manual verification (out of CI)
+
+- `pnpm dev` to boot a local server.
+- Connect ChatGPT custom MCP connector to `http://localhost:3000/mcp`.
+- Trigger a Deep Research run that hits both `search` and `fetch`.
+- Confirm citations render with our URLs.
+
+Documented in the PR body, not gated in CI (the OpenAI Responses API requires an API key + cost).
+
+---
+
+## 8. Out of scope (explicit non-goals)
+
+- Renaming any of the OGD tools (`meteoswissLocalForecast`, `meteoswissCurrentWeather`, etc.). Those are not on the Deep Research path.
+- Switching the search response from the `{totalResults, page, pageSize, results}` wrapper to a bare `{results}` — would break other clients and is unnecessary.
+- Removing the `content` alias — that's a 3.0 task.
+- Implementing the `outputSchema` (MCP 2025-11-25 typed-output feature) — would be nice for ChatGPT clients that *do* read `structuredContent`, but not required.
+- Adding pagination to `fetch` (à la `mcp-fetch` server's `start_index`/`max_length`) — our pages are small.
+- Apps SDK / Developer Mode integration (mode b) — separate plan if/when needed.
+
+---
+
+## 9. Rollout
+
+Single PR from `feature/chatgpt-fetch-compat` → `main`.
+
+Commits (atomic, in this order):
+1. `docs/plans: chatgpt fetch compat plan` — this document.
+2. `meteoswiss-mcp: add chatgpt fetch/search compat tests` — the new compat test suite + snapshot. **Will fail** until step 3 lands; structured this way so the failure proves the regression. (Will be combined with step 3 in the PR; can be split locally if reviewing.)
+3. `meteoswiss-mcp: restore id/text fields for chatgpt deep research` — the source fix + updated existing test. New tests now pass.
+4. `changeset: chatgpt fetch compat` — patch-level changeset. Bug fix only.
+
+Patch-level (`meteoswiss-mcp: patch`) is appropriate because:
+- Behavioural change is restricted to the `fetch` tool's argument naming (rename `url` → `id`).
+- The new `text` and top-level `url` fields are *additions* to the response — non-breaking for any client that reads `content` and `metadata.url`.
+- The `content` alias preserves the v2.3.1 response shape for all consumers.
+
+If anyone is somehow calling production `fetch` with `{url: …}` today (24-hour window since v2.3.1 release), they'll need to switch to `{id: …}` after the next release. That's a documented patch-level break, justified because v2.3.1 itself was the broken release.
+
+---
+
+## 10. References
+
+- OpenAI Cookbook MCP server example (Python, `fastmcp`) — canonical Deep Research reference:
+  <https://github.com/openai/openai-cookbook/blob/main/examples/deep_research_api/how_to_build_a_deep_research_mcp_server/main.py>
+  (commit 012c79d3, 2025-06-26)
+- Vercel Labs `deep-research-server` (TypeScript, `mcp-handler`) — canonical TS reference:
+  <https://github.com/vercel-labs/deep-research-server/blob/main/app/mcp/route.ts>
+- OpenAI MCP integration overview:
+  <https://developers.openai.com/api/docs/mcp> (accessed 2026-04-19)
+- OpenAI Deep Research API guide:
+  <https://developers.openai.com/api/docs/guides/deep-research> (accessed 2026-04-19)
+- OpenAI Apps SDK MCP server guide (Developer Mode pathway):
+  <https://developers.openai.com/apps-sdk/build/mcp-server> (accessed 2026-04-19)
+- OpenAI Responses API tools/connectors guide:
+  <https://developers.openai.com/api/docs/guides/tools-connectors-mcp> (accessed 2026-04-19)
+- ChatGPT custom MCP Developer Mode (community confirmation + arbitrary tool names):
+  <https://medium.com/@alexeylark/chatgpt-custom-mcp-connectors-with-developer-mode-d791fde17d25>
+  <https://gist.github.com/ruvnet/7b6843c457822cbcf42fc4aa635eadbb>
+- MCP 2025-11-25 specification, Tools page:
+  <https://modelcontextprotocol.io/specification/2025-11-25/server/tools>
+- MCP TypeScript SDK releases (1.21–2.0-alpha):
+  <https://github.com/modelcontextprotocol/typescript-sdk/releases>
+- Generic `mcp-fetch` reference server (NOT the Deep Research one):
+  <https://github.com/modelcontextprotocol/servers/tree/main/src/fetch>
+- Regressing commit: `de9c937` *"B: Fix international city blocklist, NOTASTATION geocoding guard, fetch url param"* (2026-04-18).
+- Original `id` introduction: `d6b1c62` *"Prod promotion: monorepo, rename, docs overhaul"* (2026-03-29).

--- a/docs/plans/2026-04-19-chatgpt-fetch-compat.md
+++ b/docs/plans/2026-04-19-chatgpt-fetch-compat.md
@@ -1,0 +1,162 @@
+# Plan: ChatGPT Deep Research `fetch`/`search` Compatibility
+
+> Restore canonical ChatGPT Deep Research MCP tool contract for `fetch` (param: `id`, response field: `text`) and lock it in with a regression test suite + serialized tool-manifest snapshot.
+
+## Status
+
+- **Phase:** Draft
+- **Type:** bug
+- **Sprint:**
+
+## Problem
+
+ChatGPT Deep Research consumes MCP servers via two well-known tools — `search` and `fetch` — with a tightly defined input/output contract. The current `meteoswiss-mcp` implementation diverges from that contract on `fetch`:
+
+| Field | ChatGPT spec (canonical) | `meteoswiss-mcp` today | Status |
+|---|---|---|---|
+| `fetch` input arg | `id: string` | `url: string` | ❌ incompatible |
+| `fetch` response payload field for body | `text` | `content` | ❌ incompatible |
+| `fetch` response payload structure | `{id, title, text, url, metadata}` | `{id, title, content, format, metadata}` | ❌ incompatible |
+| `search` input arg | `query: string` | `query: string` (+ optional extras) | ✅ compatible |
+| `search` response payload | `{results: [{id, title, url, text?}]}` | `{totalResults, page, pageSize, results: [{id, title, url, description, …}]}` | ✅ tolerated (extra fields OK; ChatGPT looks for `results[]` with `id`/`title`/`url`) |
+| MCP envelope | `{content: [{type: "text", text: <JSON>}]}` | same | ✅ |
+
+### Origin of the regression
+
+`packages/meteoswiss-mcp/src/schemas/meteoswiss-fetch.ts` was created with `id` as the param name (commit d6b1c62, original monorepo introduction). On 2026-04-18 commit **de9c937** ("B: Fix international city blocklist, NOTASTATION geocoding guard, fetch url param") explicitly renamed `id → url` with the message *"Revert fetch schema param id → url (rc.3 rename was unintentional)"*. Git history disagrees: `id` has been the param name since the schema file was first added, and was kept through rc.3. The de9c937 reversion is therefore itself the regression — and it landed in `2.3.1` (the version currently in production).
+
+There is no integration regression test that asserts ChatGPT-shaped calls succeed, so the rename slipped through CI. The existing `test/integration/meteoswiss-fetch.test.ts:34` actively *enforces* the broken shape (`url` as the required field).
+
+### Authoritative sources (cited in the test suite)
+
+- **OpenAI Cookbook — official Deep Research MCP example:**
+  - <https://github.com/openai/openai-cookbook/blob/main/examples/deep_research_api/how_to_build_a_deep_research_mcp_server/main.py>
+  - Verbatim: `async def fetch(id: str) -> Dict[str, Any]:` returning `{"id": …, "title": …, "text": file_content, "url": …, "metadata": …}`
+- **Vercel Labs reference TypeScript implementation:**
+  - <https://github.com/vercel-labs/deep-research-server/blob/main/app/mcp/route.ts>
+  - Verbatim Zod schema: `{ id: z.string().describe("Document ID from search results") }`, returning `{id, title, text, url, metadata}`
+- **OpenAI developer docs — MCP integration overview:** <https://developers.openai.com/api/docs/mcp>
+- **OpenAI Deep Research API guide:** <https://platform.openai.com/docs/guides/deep-research>
+- **MCP TypeScript SDK** (`@modelcontextprotocol/sdk` 1.28+): tool registration with `server.tool(name, description, schema, handler)` is unchanged in 1.28.0; the protocol envelope (`content: [{type: 'text', text: ...}]`) is stable. No SDK rename motivated the de9c937 reversion.
+
+## Current state
+
+- `meteoswiss-mcp` v2.3.1 deployed at <https://meteoswiss-mcp.ars.is/mcp>.
+- `fetch` tool refuses ChatGPT-shaped calls: `tools/call {name: "fetch", arguments: {id: "<url>"}}` → Zod validation error (unknown property `id`, missing required `url`).
+- Even when called with `{url: …}`, response body has `text` field absent → ChatGPT parses a record with no body content.
+- `search` works as-is for ChatGPT; the wrapping object adds harmless extra keys.
+
+## Target state
+
+1. **`fetch` accepts `id` as the canonical param name** (matches OpenAI cookbook + Vercel reference).
+2. **`fetch` accepts `url` as a deprecated alias** for one minor version, so any custom client that started relying on the de9c937-era shape doesn't immediately break. Schema rejects the call only if *neither* is provided. Aliasing is implemented with a Zod `preprocess` step — at the schema level the canonical name remains `id`.
+3. **`fetch` response includes a `text` field** with the body content (in addition to the existing `content` field for one minor version, for the same back-compat reason).
+4. A **dedicated compat integration test suite** asserts:
+   - `tools/list` exposes a `fetch` tool whose JSON Schema declares `id` as a required string.
+   - Calling `fetch` with `{id: "<url>"}` succeeds and the parsed text payload contains all five canonical fields (`id`, `title`, `text`, `url`, `metadata`).
+   - Calling `fetch` with `{url: "<url>"}` (legacy) still succeeds.
+   - Calling `search` with `{query: "<…>"}` returns a payload whose parsed JSON contains a `results` array of objects with `id`, `title`, `url`.
+   - The MCP envelope (`content[0].type === "text"`, `content[0].text` is parseable JSON) holds.
+5. A **tool-manifest snapshot** (`test/__snapshots__/chatgpt-compat.test.ts.snap`) captures the serialized `tools/list` output for `search` and `fetch` (name, description, `inputSchema.properties.*`, `inputSchema.required`). Future renames or rearrangements break the snapshot, forcing an explicit acknowledgement.
+6. Existing `test/integration/meteoswiss-fetch.test.ts` is updated to use `id` (or both, to demonstrate the alias) so it stops enforcing the broken shape.
+
+## Design
+
+### Schema change (`src/schemas/meteoswiss-fetch.ts`)
+
+```ts
+// Canonical name is `id` (matches OpenAI cookbook/Vercel reference).
+// Accept `url` as a deprecated alias for back-compat with v2.3.1 callers.
+export const fetchMeteoSwissContentSchema = z
+  .preprocess((value) => {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      const v = value as Record<string, unknown>;
+      if (v.id === undefined && typeof v.url === 'string') {
+        return { ...v, id: v.url };
+      }
+    }
+    return value;
+  }, z.object({
+    id: z.string().min(1, { /* … */ }).describe('…'),
+    format: z.enum(['markdown', 'text']).optional().default('markdown'),
+    includeMetadata: z.boolean().optional().default(true),
+  }));
+```
+
+Rationale: `preprocess` keeps the JSON Schema seen by ChatGPT clean (only `id` shows up in `tools/list`), while still accepting legacy `url` calls at runtime. The runtime type stays `{id: string, format: …, includeMetadata: …}`.
+
+### Response shape change (`src/data/meteoswiss-content-data.ts`)
+
+```ts
+export interface ContentResponse {
+  id: string;
+  title?: string;
+  text: string;            // canonical (ChatGPT)
+  /** @deprecated kept for back-compat with v2.3.1 — will be removed in 3.0 */
+  content: string;
+  format: 'markdown' | 'text';
+  url?: string;            // canonical (ChatGPT) — equals id when id is a URL
+  metadata?: { … };
+}
+```
+
+`processHtmlContent` populates both `text` and `content` with the same string for one minor version. `url` is set to the resolved full URL (which is also `id` for our server, since our IDs *are* URLs).
+
+### Server registration (`src/server.ts`)
+
+No change needed beyond the schema/response updates. The `params.url` reference at line 114 becomes `params.id` (post-preprocess) — and the log line + handler call switch accordingly.
+
+### Tests
+
+- **New file:** `packages/meteoswiss-mcp/test/integration/chatgpt-compat.test.ts`
+  - Boots the server via the existing `MCPClient`.
+  - Asserts `tools/list` has `search` + `fetch` with the spec'd schemas.
+  - Asserts `fetch` with `{id: …}` happy path.
+  - Asserts `fetch` with `{url: …}` legacy path.
+  - Asserts `search` happy path.
+  - Asserts MCP envelope shape (`content[0].type === 'text'`, JSON-parseable text).
+  - Snapshot-asserts the manifest entries for `search` + `fetch`.
+- **Updated file:** `packages/meteoswiss-mcp/test/integration/meteoswiss-fetch.test.ts`
+  - Switch the schema-shape assertion at L31–L52 from `url` (required) to `id` (required).
+  - Switch the call-tool inputs from `{url: …}` to `{id: …}`.
+  - Replace `result.content` body assertions with `result.text` (keep one assertion that `result.content === result.text` to lock in the back-compat alias).
+
+### Snapshot policy
+
+The snapshot lives at `test/__snapshots__/chatgpt-compat.test.ts.snap`. Reviewers must explicitly approve any change to it. The snapshot includes:
+
+- `name`
+- `description`
+- `inputSchema.type`
+- `inputSchema.properties[*].type` and `properties[*].description`
+- `inputSchema.required` (sorted)
+
+It **excludes** generated/volatile fields like JSON-schema `$id`, ordering inside non-required arrays, and zod-generated metadata fields, so it's stable across SDK patch bumps.
+
+## Test plan
+
+1. New `chatgpt-compat.test.ts` passes (new ChatGPT-shaped calls succeed; snapshot matches).
+2. Updated `meteoswiss-fetch.test.ts` passes with `id` as the canonical param.
+3. Other integration tests continue to pass (no regression to OGD tools).
+4. `pnpm --filter meteoswiss-mcp run ci` is green (lint, build, test).
+5. Manual smoke: connect ChatGPT custom MCP connector to a local server (`pnpm dev`) and verify a Deep Research run completes end-to-end. *Note: not gated in CI; documented in PR body.*
+
+## Out of scope
+
+- Renaming any of the OGD tools (`meteoswissLocalForecast`, etc.).
+- Changing the search response shape — the wrapper `{totalResults, page, pageSize, results}` is tolerated by ChatGPT and used by other clients; a breaking change there would require a major bump.
+- Removing the `url` alias and the `content` legacy field — that's a 3.0 task tracked separately.
+
+## Rollout
+
+Single PR from `feature/chatgpt-fetch-compat` → `main`. Patch-level changeset (`meteoswiss-mcp: patch`) since the change is bug-fix-only and additive at the schema level (legacy `url` and `content` still work). Post-merge: standard Changesets bot release flow.
+
+## References
+
+- OpenAI Cookbook MCP server example: <https://github.com/openai/openai-cookbook/blob/main/examples/deep_research_api/how_to_build_a_deep_research_mcp_server/main.py>
+- Vercel deep-research-server: <https://github.com/vercel-labs/deep-research-server/blob/main/app/mcp/route.ts>
+- OpenAI Developer docs (MCP): <https://developers.openai.com/api/docs/mcp>
+- OpenAI Deep Research API: <https://platform.openai.com/docs/guides/deep-research>
+- MCP TypeScript SDK: <https://github.com/modelcontextprotocol/typescript-sdk>
+- Regressing commit: `de9c937` (B: Fix international city blocklist, NOTASTATION geocoding guard, fetch url param)
+- Original `id` introduction: `d6b1c62` (Prod promotion: monorepo, rename, docs overhaul)

--- a/packages/meteoswiss-mcp/src/data/meteoswiss-content-data.ts
+++ b/packages/meteoswiss-mcp/src/data/meteoswiss-content-data.ts
@@ -46,13 +46,22 @@ const turndownService = new TurndownService({
 turndownService.use(gfm);
 
 /**
- * Content response structure
+ * Content response structure.
+ *
+ * Field naming follows the ChatGPT Deep Research MCP contract:
+ * `id`, `title`, `text`, `url`, `metadata`. The `content` field is kept
+ * as a back-compat alias for `text` and will be removed in 3.0.
  */
 export interface ContentResponse {
   id: string;
   title?: string;
+  /** Canonical body field (matches ChatGPT Deep Research spec). */
+  text: string;
+  /** @deprecated Alias of `text` kept for back-compat with v2.3.x callers. Will be removed in 3.0. */
   content: string;
   format: 'markdown' | 'text';
+  /** Canonical URL field (matches ChatGPT Deep Research spec). For this server `url === id`. */
+  url: string;
   metadata?: {
     url: string;
     language?: string;
@@ -64,7 +73,9 @@ export interface ContentResponse {
 }
 
 /**
- * Fetch MeteoSwiss content by ID
+ * Fetch MeteoSwiss content by ID.
+ *
+ * The `id` parameter is a full MeteoSwiss page URL returned by the search tool.
  *
  * @param params Fetch parameters
  * @returns Content response
@@ -72,35 +83,37 @@ export interface ContentResponse {
 export async function fetchMeteoSwissContent(
   params: FetchMeteoSwissContentInput
 ): Promise<ContentResponse> {
-  const { url, format = 'markdown', includeMetadata = true } = params;
+  const { id, format = 'markdown', includeMetadata = true } = params;
 
   debugData('fetchMeteoSwissContent called with params: %o', {
-    url,
+    id,
     format,
     includeMetadata,
   });
 
   if (USE_TEST_FIXTURES) {
     debugData('Using test fixtures for content fetch');
-    return fetchFromTestFixtures(url, format, includeMetadata);
+    return fetchFromTestFixtures(id, format, includeMetadata);
   }
 
   debugData('Using live API for content fetch');
-  return fetchFromWeb(url, format, includeMetadata);
+  return fetchFromWeb(id, format, includeMetadata);
 }
 
 /**
- * Fetch content from the web
+ * Fetch content from the web.
+ *
+ * @param id The page id — a full URL or a path returned by the search tool.
  */
 async function fetchFromWeb(
-  url: string,
+  id: string,
   format: 'markdown' | 'text',
   includeMetadata: boolean
 ): Promise<ContentResponse> {
   // Normalise to full URL (accept full URLs; prepend base for bare paths for backward compat)
-  const fullUrl = url.startsWith('http')
-    ? url
-    : `https://www.meteoswiss.admin.ch${url.startsWith('/') ? url : '/' + url}`;
+  const fullUrl = id.startsWith('http')
+    ? id
+    : `https://www.meteoswiss.admin.ch${id.startsWith('/') ? id : '/' + id}`;
 
   debugData('Fetching content from URL: %s', fullUrl);
 
@@ -136,7 +149,7 @@ async function fetchFromWeb(
     debugData('Content fetch error: %o', error);
     if (error instanceof HttpRequestError && error.statusCode === 404) {
       throw new Error(
-        `Content not found: ${url}. Use the search tool to discover valid page URLs.`,
+        `Content not found: ${id}. Use the search tool to discover valid page URLs.`,
         { cause: error }
       );
     }
@@ -148,21 +161,23 @@ async function fetchFromWeb(
 }
 
 /**
- * Fetch content from test fixtures
+ * Fetch content from test fixtures.
+ *
+ * @param id The page id — a full URL or a path returned by the search tool.
  */
 async function fetchFromTestFixtures(
-  url: string,
+  id: string,
   format: 'markdown' | 'text',
   includeMetadata: boolean
 ): Promise<ContentResponse> {
-  debugData('Looking for test fixture for URL: %s', url);
+  debugData('Looking for test fixture for id: %s', id);
 
   // Extract language from URL if it's a full URL
   let detectedLang = 'de';
-  let urlPath = url;
+  let urlPath = id;
 
-  if (url.startsWith('http')) {
-    const parsed = new URL(url);
+  if (id.startsWith('http')) {
+    const parsed = new URL(id);
     urlPath = parsed.pathname;
 
     // Detect language from domain
@@ -189,14 +204,14 @@ async function fetchFromTestFixtures(
     if (existsSync(fixtureFile)) {
       debugData('Loading test fixture from: %s', fixtureFile);
       const html = await fs.readFile(fixtureFile, 'utf-8');
-      const fullUrl = url.startsWith('http') ? url : `https://www.meteoswiss.admin.ch${url}`;
+      const fullUrl = id.startsWith('http') ? id : `https://www.meteoswiss.admin.ch${id}`;
 
       return processHtmlContent(html, fullUrl, format, includeMetadata);
     }
   }
 
-  debugData('No test fixture found for URL: %s', url);
-  throw new Error(`Content not found: ${url}`);
+  debugData('No test fixture found for id: %s', id);
+  throw new Error(`Content not found: ${id}`);
 }
 
 /**
@@ -275,8 +290,10 @@ function processHtmlContent(
   return {
     id: url,
     title,
+    text: content,
     content,
     format,
+    url,
     metadata,
   };
 }

--- a/packages/meteoswiss-mcp/src/schemas/meteoswiss-fetch.ts
+++ b/packages/meteoswiss-mcp/src/schemas/meteoswiss-fetch.ts
@@ -1,14 +1,19 @@
 import { z } from 'zod';
 
 /**
- * Schema for fetch tool parameters
+ * Schema for fetch tool parameters.
+ *
+ * Canonical input arg is `id` to match the ChatGPT Deep Research MCP contract:
+ * <https://github.com/openai/openai-cookbook/blob/main/examples/deep_research_api/how_to_build_a_deep_research_mcp_server/main.py>
+ *
+ * For this server the `id` is a full MeteoSwiss page URL returned by the search tool.
  */
 export const fetchMeteoSwissContentSchema = z.object({
-  url: z
+  id: z
     .string()
-    .min(1, { message: 'URL cannot be empty. Use the search tool to find valid page URLs.' })
+    .min(1, { message: 'id cannot be empty. Use the search tool to find valid page URLs.' })
     .describe(
-      'Full URL of a MeteoSwiss page to fetch. Use the search tool first to discover valid URLs. Example: https://www.meteoschweiz.admin.ch/klima/klimawandel/steigende-temperaturen.html'
+      'Identifier of a MeteoSwiss page to fetch. For this server the id is a full URL returned by the search tool. Example: https://www.meteoschweiz.admin.ch/klima/klimawandel/steigende-temperaturen.html'
     ),
   format: z
     .enum(['markdown', 'text'], {

--- a/packages/meteoswiss-mcp/src/server.ts
+++ b/packages/meteoswiss-mcp/src/server.ts
@@ -111,7 +111,7 @@ export function createServer(): McpServer {
       const _t0 = performance.now();
       try {
         console.error(
-          `Processing fetch request: url="${params.url}", format=${params.format || 'markdown'}`
+          `Processing fetch request: id="${params.id}", format=${params.format || 'markdown'}`
         );
         debugTools('fetch called with params: %O', params);
         const content = await meteoswissFetchTool(params);

--- a/packages/meteoswiss-mcp/src/tools/meteoswiss-fetch.ts
+++ b/packages/meteoswiss-mcp/src/tools/meteoswiss-fetch.ts
@@ -22,7 +22,7 @@ export async function meteoswissFetchTool(input: unknown): Promise<unknown> {
   try {
     // Fetch the content
     const content = await fetchMeteoSwissContent(params);
-    debugTools('Fetched content for URL: %s', params.url);
+    debugTools('Fetched content for id: %s', params.id);
 
     return content;
   } catch (error) {

--- a/packages/meteoswiss-mcp/test/integration/__snapshots__/chatgpt-compat.test.ts.snap
+++ b/packages/meteoswiss-mcp/test/integration/__snapshots__/chatgpt-compat.test.ts.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ChatGPT Deep Research compatibility manifest snapshot matches the canonical ChatGPT tool-manifest shape 1`] = `
+{
+  "fetch": {
+    "description": "Fetch full content from a MeteoSwiss webpage and convert to markdown or plain text. Use the search tool first to discover valid page URLs, then pass the full URL as the id parameter.",
+    "inputSchema": {
+      "properties": {
+        "format": {
+          "default": "markdown",
+          "description": "The output format for the content",
+          "enum": [
+            "markdown",
+            "text",
+          ],
+          "type": "string",
+        },
+        "id": {
+          "description": "Identifier of a MeteoSwiss page to fetch. For this server the id is a full URL returned by the search tool. Example: https://www.meteoschweiz.admin.ch/klima/klimawandel/steigende-temperaturen.html",
+          "type": "string",
+        },
+        "includeMetadata": {
+          "default": true,
+          "description": "Whether to include metadata in the response",
+          "type": "boolean",
+        },
+      },
+      "required": [
+        "id",
+      ],
+      "type": "object",
+    },
+    "name": "fetch",
+  },
+  "search": {
+    "description": "Search MeteoSwiss website content in multiple languages (DE, FR, IT, EN). Returns relevant pages with URLs that can be passed to the fetch tool. Note: pagination may return duplicate results across pages (upstream API limitation).",
+    "inputSchema": {
+      "properties": {
+        "contentType": {
+          "description": "Filter by content type. Defaults to "content" to exclude application pages. Use "publication" for official reports.",
+          "enum": [
+            "content",
+            "press-release",
+            "blog-article",
+            "publication",
+          ],
+          "type": "string",
+        },
+        "language": {
+          "default": "de",
+          "description": "The language for search results",
+          "enum": [
+            "de",
+            "fr",
+            "it",
+            "en",
+          ],
+          "type": "string",
+        },
+        "page": {
+          "default": 1,
+          "description": "Page number for pagination (1-based)",
+          "type": "integer",
+        },
+        "pageSize": {
+          "default": 12,
+          "description": "Number of results per page (max 100)",
+          "type": "integer",
+        },
+        "query": {
+          "description": "The search query string",
+          "type": "string",
+        },
+        "sort": {
+          "default": "relevance",
+          "description": "Sort order for results. Note: date-asc severely degrades relevance — results are dominated by page age rather than query match.",
+          "enum": [
+            "relevance",
+            "date-desc",
+            "date-asc",
+          ],
+          "type": "string",
+        },
+      },
+      "required": [
+        "query",
+      ],
+      "type": "object",
+    },
+    "name": "search",
+  },
+}
+`;

--- a/packages/meteoswiss-mcp/test/integration/chatgpt-compat.test.ts
+++ b/packages/meteoswiss-mcp/test/integration/chatgpt-compat.test.ts
@@ -1,0 +1,223 @@
+/**
+ * ChatGPT Deep Research / Custom Connector compatibility regression suite.
+ *
+ * These tests pin the meteoswiss-mcp `search` and `fetch` tools to the
+ * canonical contract that ChatGPT (Deep Research, Connectors, and Responses
+ * API direct integration) requires. See:
+ *
+ *   docs/plans/2026-04-19-chatgpt-fetch-compat.md
+ *
+ * The contract (verbatim from the OpenAI cookbook + Vercel reference):
+ *
+ *   search(query: string)
+ *     → { results: Array<{ id: string; title: string; text?: string; url: string }> }
+ *
+ *   fetch(id: string)
+ *     → { id: string; title: string; text: string; url: string; metadata?: object | null }
+ *
+ *   MCP envelope: { content: [{ type: "text", text: "<JSON.stringify(payload)>" }] }
+ *
+ * Sources:
+ *   - https://github.com/openai/openai-cookbook/blob/main/examples/deep_research_api/how_to_build_a_deep_research_mcp_server/main.py
+ *   - https://github.com/vercel-labs/deep-research-server/blob/main/app/mcp/route.ts
+ *   - https://developers.openai.com/api/docs/mcp
+ *
+ * The companion snapshot at test/__snapshots__/chatgpt-compat.test.ts.snap
+ * captures the serialized tool manifest for `search` and `fetch`. Any future
+ * rename, type change, or required-field shift will diff the snapshot and
+ * force the reviewer to either approve the change (and confirm it's still
+ * ChatGPT-compatible) or revert it.
+ */
+import { describe, expect, it, jest, beforeAll, afterAll } from '@jest/globals';
+import { MCPClient } from './mcp-client.js';
+
+const FIXTURE_FETCH_PATH = '/wetter/gefahren/verhaltensempfehlungen/wind.html';
+const FIXTURE_SEARCH_QUERY = 'wetter';
+
+/**
+ * Deterministic serializer for a tool manifest entry, used by the snapshot
+ * assertion. Strips zod-generated noise (e.g. `additionalProperties: false`
+ * may shift between SDK patches) and sorts arrays/keys so the snapshot is
+ * stable across non-meaningful churn.
+ */
+function normaliseToolManifest(tool: {
+  name: string;
+  description?: string;
+  inputSchema?: { type?: string; properties?: Record<string, unknown>; required?: string[] };
+}): Record<string, unknown> {
+  const properties = tool.inputSchema?.properties ?? {};
+  const sortedProps = Object.fromEntries(
+    Object.keys(properties)
+      .sort()
+      .map((key) => {
+        const prop = properties[key] as Record<string, unknown> | undefined;
+        if (!prop) return [key, prop];
+        // Keep only the fields ChatGPT actually reads + the description (so a
+        // wording change forces a snapshot diff).
+        const kept: Record<string, unknown> = {};
+        for (const field of ['type', 'description', 'enum', 'default'] as const) {
+          if (field in prop) kept[field] = prop[field];
+        }
+        return [key, kept];
+      })
+  );
+  return {
+    name: tool.name,
+    description: tool.description,
+    inputSchema: {
+      type: tool.inputSchema?.type ?? 'object',
+      properties: sortedProps,
+      required: [...(tool.inputSchema?.required ?? [])].sort(),
+    },
+  };
+}
+
+type ToolManifest = {
+  name: string;
+  description?: string;
+  inputSchema?: { type?: string; properties?: Record<string, unknown>; required?: string[] };
+};
+
+describe('ChatGPT Deep Research compatibility', () => {
+  let client: MCPClient;
+  let manifest: ToolManifest[];
+
+  beforeAll(async () => {
+    process.env.USE_TEST_FIXTURES = 'true';
+    client = new MCPClient();
+    await client.start();
+    manifest = (await client.listTools()) as ToolManifest[];
+  });
+
+  afterAll(async () => {
+    await client.stop();
+    jest.restoreAllMocks();
+  });
+
+  describe('tool discovery (tools/list)', () => {
+    it('exposes a tool named "search"', () => {
+      const tool = manifest.find((t) => t.name === 'search');
+      expect(tool).toBeDefined();
+    });
+
+    it('exposes a tool named "fetch"', () => {
+      const tool = manifest.find((t) => t.name === 'fetch');
+      expect(tool).toBeDefined();
+    });
+
+    it('declares search.inputSchema with required `query: string`', () => {
+      const tool = manifest.find((t) => t.name === 'search');
+      const props = tool?.inputSchema?.properties as
+        | Record<string, { type?: string }>
+        | undefined;
+      expect(props?.query?.type).toBe('string');
+      expect(tool?.inputSchema?.required).toContain('query');
+    });
+
+    it('declares fetch.inputSchema with required `id: string` (canonical ChatGPT shape)', () => {
+      const tool = manifest.find((t) => t.name === 'fetch');
+      const props = tool?.inputSchema?.properties as
+        | Record<string, { type?: string }>
+        | undefined;
+
+      // The whole point of this test: ChatGPT calls fetch with {id: "..."}.
+      // If this assertion fails, ChatGPT cannot call our fetch tool.
+      expect(props?.id).toBeDefined();
+      expect(props?.id?.type).toBe('string');
+      expect(tool?.inputSchema?.required).toContain('id');
+
+      // `url` was the v2.3.1 regression name — must NOT be the required field.
+      expect(tool?.inputSchema?.required ?? []).not.toContain('url');
+    });
+  });
+
+  describe('search tool runtime', () => {
+    it('returns a ChatGPT-shaped payload when called with {query}', async () => {
+      const response = await client.callTool('search', { query: FIXTURE_SEARCH_QUERY });
+
+      // MCP envelope: content[] with type: "text".
+      expect(response.content).toBeDefined();
+      expect(response.content[0]?.type).toBe('text');
+      expect(typeof response.content[0]?.text).toBe('string');
+
+      // Body must be JSON-parseable.
+      const body = JSON.parse(response.content[0].text);
+
+      // ChatGPT looks for a `results` array.
+      expect(Array.isArray(body.results)).toBe(true);
+      expect(body.results.length).toBeGreaterThan(0);
+
+      // Each result must have id, title, url (per cookbook + Vercel reference).
+      const first = body.results[0];
+      expect(typeof first.id).toBe('string');
+      expect(first.id.length).toBeGreaterThan(0);
+      expect(typeof first.title).toBe('string');
+      expect(first.title.length).toBeGreaterThan(0);
+      expect(typeof first.url).toBe('string');
+      expect(first.url).toMatch(/^https?:\/\//);
+    });
+  });
+
+  describe('fetch tool runtime', () => {
+    it('returns a ChatGPT-shaped payload when called with {id}', async () => {
+      const response = await client.callTool('fetch', { id: FIXTURE_FETCH_PATH });
+
+      // MCP envelope.
+      expect(response.content).toBeDefined();
+      expect(response.content[0]?.type).toBe('text');
+      expect(typeof response.content[0]?.text).toBe('string');
+
+      // Body must be JSON-parseable.
+      const body = JSON.parse(response.content[0].text);
+
+      // ChatGPT canonical shape: {id, title, text, url, metadata?}.
+      expect(typeof body.id).toBe('string');
+      expect(body.id.length).toBeGreaterThan(0);
+      expect(typeof body.title).toBe('string');
+      expect(body.title.length).toBeGreaterThan(0);
+
+      // `text` is the canonical body field. ChatGPT renders citations from it.
+      expect(typeof body.text).toBe('string');
+      expect(body.text.length).toBeGreaterThan(0);
+
+      // `url` at the top level (not just in metadata) is the canonical citation field.
+      expect(typeof body.url).toBe('string');
+      expect(body.url).toMatch(/^https?:\/\//);
+    });
+
+    it('preserves `content` as a back-compat alias of `text`', async () => {
+      // Documented in docs/plans/2026-04-19-chatgpt-fetch-compat.md §6.3.
+      // `content` is the v2.3.x field name; kept for one minor version so we don't
+      // break existing consumers in the same patch that adds `text`.
+      const response = await client.callTool('fetch', { id: FIXTURE_FETCH_PATH });
+      const body = JSON.parse(response.content[0].text);
+      expect(body.content).toBe(body.text);
+    });
+
+    it('rejects calls that omit the `id` argument', async () => {
+      // MCP SDK either throws (Streamable HTTP path) or returns isError: true.
+      // Either is acceptable per MCP 2025-11-25 §Error Handling.
+      const result = await client
+        .callTool('fetch', {})
+        .catch((e: Error) => ({ isError: true, content: [{ text: e.message }] }));
+      const failed =
+        result.isError === true ||
+        (typeof result.content?.[0]?.text === 'string' &&
+          result.content[0].text.toLowerCase().includes('id'));
+      expect(failed).toBe(true);
+    });
+  });
+
+  describe('manifest snapshot', () => {
+    it('matches the canonical ChatGPT tool-manifest shape', () => {
+      const search = manifest.find((t) => t.name === 'search');
+      const fetchTool = manifest.find((t) => t.name === 'fetch');
+      expect(search).toBeDefined();
+      expect(fetchTool).toBeDefined();
+      expect({
+        search: normaliseToolManifest(search!),
+        fetch: normaliseToolManifest(fetchTool!),
+      }).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/meteoswiss-mcp/test/integration/meteoswiss-fetch.test.ts
+++ b/packages/meteoswiss-mcp/test/integration/meteoswiss-fetch.test.ts
@@ -31,30 +31,30 @@ describe('MeteoSwiss Fetch Tool', () => {
       expect(fetchTool?.inputSchema).toMatchObject({
         type: 'object',
         properties: {
-          url: {
+          id: {
             type: 'string',
-            description: expect.stringContaining('URL')
+            description: expect.stringContaining('Identifier'),
           },
           format: {
             type: 'string',
             enum: ['markdown', 'text'],
             default: 'markdown',
-            description: expect.stringContaining('output format')
+            description: expect.stringContaining('output format'),
           },
           includeMetadata: {
             type: 'boolean',
             default: true,
-            description: expect.stringContaining('metadata')
-          }
+            description: expect.stringContaining('metadata'),
+          },
         },
-        required: ['url']
+        required: ['id'],
       });
     });
 
-    it('should fetch content by URL in markdown format', async () => {
+    it('should fetch content by id in markdown format', async () => {
       const response = await client.callTool('fetch', {
-        url: '/wetter/gefahren/verhaltensempfehlungen/wind.html',
-        format: 'markdown'
+        id: '/wetter/gefahren/verhaltensempfehlungen/wind.html',
+        format: 'markdown',
       });
 
       const result = JSON.parse(response.content[0].text);
@@ -62,43 +62,49 @@ describe('MeteoSwiss Fetch Tool', () => {
       expect(result).toMatchObject({
         id: expect.stringContaining('/wetter/gefahren/verhaltensempfehlungen/wind.html'),
         title: expect.any(String),
-        content: expect.stringContaining('#'), // Markdown heading
+        text: expect.stringContaining('#'), // Markdown heading (canonical ChatGPT field)
+        content: expect.stringContaining('#'), // Back-compat alias
         format: 'markdown',
+        url: expect.stringContaining('meteoswiss'),
         metadata: expect.objectContaining({
           url: expect.stringContaining('meteoswiss'),
           language: expect.any(String),
-          contentType: expect.any(String)
-        })
+          contentType: expect.any(String),
+        }),
       });
 
-      // Content must include actual body text from web component attributes,
-      // not just the page title (regression test for empty content body bug)
-      expect(result.content).toContain('Verhaltensempfehlungen');
-      expect(result.content).toContain('Windereignisse');
-      expect(result.content).toContain('Gefahrenstufen von Wind');
+      // text and content must hold identical strings (alias guarantee from
+      // docs/plans/2026-04-19-chatgpt-fetch-compat.md §6.3).
+      expect(result.text).toBe(result.content);
+
+      // Body must include actual page text from web component attributes,
+      // not just the page title (regression guard for empty-content body bug).
+      expect(result.text).toContain('Verhaltensempfehlungen');
+      expect(result.text).toContain('Windereignisse');
+      expect(result.text).toContain('Gefahrenstufen von Wind');
     });
 
     it('should fetch content in plain text format', async () => {
       const response = await client.callTool('fetch', {
-        url: '/wetter/gefahren/verhaltensempfehlungen/wind.html',
-        format: 'text'
+        id: '/wetter/gefahren/verhaltensempfehlungen/wind.html',
+        format: 'text',
       });
 
       const result = JSON.parse(response.content[0].text);
 
       expect(result).toMatchObject({
+        text: expect.any(String),
         content: expect.any(String),
-        format: 'text'
+        format: 'text',
       });
-      expect(result.content).not.toContain('<'); // No HTML tags
-      expect(result.content).not.toContain('#'); // No markdown
+      expect(result.text).not.toContain('<'); // No HTML tags
+      expect(result.text).not.toContain('#'); // No markdown
     });
-
 
     it('should exclude metadata when requested', async () => {
       const response = await client.callTool('fetch', {
-        url: '/wetter/gefahren/verhaltensempfehlungen/wind.html',
-        includeMetadata: false
+        id: '/wetter/gefahren/verhaltensempfehlungen/wind.html',
+        includeMetadata: false,
       });
 
       const result = JSON.parse(response.content[0].text);
@@ -106,10 +112,9 @@ describe('MeteoSwiss Fetch Tool', () => {
       expect(result.metadata).toBeUndefined();
     });
 
-
-    it('should handle non-existent content URLs', async () => {
+    it('should handle non-existent content ids', async () => {
       const response = await client.callTool('fetch', {
-        url: '/non-existent-page.html'
+        id: '/non-existent-page.html',
       });
 
       expect(response.isError).toBe(true);
@@ -120,7 +125,7 @@ describe('MeteoSwiss Fetch Tool', () => {
       // MCP SDK may throw (SSE) or return error result (Streamable HTTP) for invalid params
       const result = await client
         .callTool('fetch', {
-          url: '/wetter/gefahren/verhaltensempfehlungen/wind.html',
+          id: '/wetter/gefahren/verhaltensempfehlungen/wind.html',
           format: 'invalid',
         })
         .catch((e: Error) => ({ isError: true, content: [{ text: e.message }] }));
@@ -132,7 +137,7 @@ describe('MeteoSwiss Fetch Tool', () => {
 
       // First fetch - may be slower
       const firstResponse = await client.callTool('fetch', {
-        url: '/wetter/gefahren/verhaltensempfehlungen/wind.html'
+        id: '/wetter/gefahren/verhaltensempfehlungen/wind.html',
       });
 
       const firstFetchTime = Date.now() - startTime;
@@ -140,10 +145,11 @@ describe('MeteoSwiss Fetch Tool', () => {
       // Second fetch - should be cached and faster
       const secondStartTime = Date.now();
       const secondResponse = await client.callTool('fetch', {
-        url: '/wetter/gefahren/verhaltensempfehlungen/wind.html'
+        id: '/wetter/gefahren/verhaltensempfehlungen/wind.html',
       });
       const secondFetchTime = Date.now() - secondStartTime;
 
+      expect(JSON.parse(firstResponse.content[0].text)).toBeDefined();
       expect(JSON.parse(secondResponse.content[0].text)).toBeDefined();
       // Caching not implemented yet, so just check that it works
       expect(secondFetchTime).toBeLessThan(firstFetchTime * 2); // Not much slower


### PR DESCRIPTION
## Summary

`meteoswiss-mcp` v2.3.1 (released 2026-04-18) is incompatible with the canonical **ChatGPT Deep Research / Connectors** MCP contract on the `fetch` tool. This PR restores compatibility and locks it in with a regression test suite + tool-manifest snapshot so the rename can't slip through CI again.

## Investigation

| Field | ChatGPT spec | v2.3.1 | This PR |
|---|---|---|---|
| `fetch` input arg | `id: string` | `url: string` ❌ | `id: string` ✅ |
| `fetch` body field | `text` | `content` ❌ | `text` (+ `content` alias for back-compat) ✅ |
| `fetch` output keys | `{id, title, text, url, metadata}` | `{id, title, content, format, metadata}` ❌ | `{id, title, text, content, format, url, metadata}` ✅ |
| `search` input | `query` | `query` ✅ | unchanged ✅ |
| MCP envelope | `content[0].type='text'` w/ JSON-stringified body | same ✅ | unchanged ✅ |

Origin: commit de9c937 (2026-04-18) renamed the param `id → url` claiming the rc.3 `id` name was an "unintentional rename". Git history disagrees — `id` has been the canonical name since the schema's first commit (d6b1c62). The reversion was itself the regression.

Authoritative sources used (verbatim, all cited in the plan):
- OpenAI Cookbook canonical Python reference: `fetch(id: str)` returning `{id, title, text, url, metadata}` — <https://github.com/openai/openai-cookbook/blob/main/examples/deep_research_api/how_to_build_a_deep_research_mcp_server/main.py>
- Vercel Labs canonical TS reference (`mcp-handler` + zod): same shape — <https://github.com/vercel-labs/deep-research-server/blob/main/app/mcp/route.ts>
- OpenAI Deep Research API guide — <https://developers.openai.com/api/docs/guides/deep-research>
- OpenAI MCP integration overview — <https://developers.openai.com/api/docs/mcp>
- MCP TypeScript SDK release scan (1.21–2.0-alpha) — no SDK-driven rename to motivate the de9c937 commit.

Full investigation, contract diff, and references in the plan doc:
- [`docs/plans/2026-04-19-chatgpt-fetch-compat.md`](https://github.com/eins78/meteoswiss-llm-tools/blob/feature/chatgpt-fetch-compat/docs/plans/2026-04-19-chatgpt-fetch-compat.md)

## What's in this PR

5 atomic commits:

1. `docs/plans: chatgpt fetch compat plan` — initial plan stub.
2. `docs/plans: expand chatgpt fetch compat plan with full research` — comprehensive plan covering all three ChatGPT integration modes (Connectors, Apps SDK Developer Mode, Responses API direct), transport/auth/protocol revision, SDK changelog scan, reference servers, contract diff, and rollout sequence.
3. `meteoswiss-mcp: add chatgpt fetch/search compat regression tests` — new `test/integration/chatgpt-compat.test.ts` (9 tests) + a normalised tool-manifest Jest snapshot. Test-only commit; intentionally fails on its own to prove the regression exists.
4. `meteoswiss-mcp: restore id/text fields for chatgpt deep research` — the source fix (4 files) + updated `test/integration/meteoswiss-fetch.test.ts`. New tests now pass.
5. `changeset: chatgpt fetch compat` — patch-level changeset.

## Back-compat

The `text` field is a new addition; `content` stays as a deprecated alias for one minor version (will be removed in 3.0). Top-level `url` is also new.

The `url` argument shape from v2.3.1 is **not** preserved as an alias — v2.3.1 was published 24 hours before this PR was opened, the operator (eins78) is the only deployment, and adding a `z.preprocess` shim would either pollute `tools/list` or hide the alias from the manifest. Pure rename is the minimal patch. See plan §6.2.

## Test plan

- [x] `pnpm --filter meteoswiss-mcp run lint` — passes (TypeScript + ESLint).
- [x] `pnpm --filter meteoswiss-mcp run build` — passes.
- [x] New `chatgpt-compat.test.ts` (9 tests) — passes including snapshot.
- [x] Existing `meteoswiss-fetch.test.ts` updated for `id` shape — passes.
- [x] Existing `meteoswiss-search.test.ts` — passes (unchanged).
- [x] All other integration suites — pass except the known macOS port-mapping flake (unrelated, pre-existing on `main`, documented as `port-mapping.test.ts` failing in parallel Jest on macOS).
- [ ] Manual verification: connect ChatGPT custom MCP connector to a live deployment and trigger a Deep Research run. Out of CI scope (requires API key + cost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
