### PR TITLE
I: Version meteoswiss-mcp v2.3.2 (ChatGPT fetch compat)

### DIFF
--- a/.changeset/chatgpt-fetch-compat.md
+++ b/.changeset/chatgpt-fetch-compat.md
@@ -1,5 +1,0 @@
----
-"meteoswiss-mcp": patch
----
-
-Restore ChatGPT Deep Research / Connectors compatibility for the `fetch` tool. The v2.3.1 release renamed the `fetch` argument from `id` to `url`, which broke the canonical contract that ChatGPT (and the OpenAI Responses API Deep Research models) expects. This release renames it back to `id`, adds the canonical `text` and top-level `url` fields to the `fetch` response, keeps `content` as a back-compat alias of `text`, and adds an integration test suite + tool-manifest snapshot to prevent the regression from recurring. See `docs/plans/2026-04-19-chatgpt-fetch-compat.md` for the full investigation and references.

--- a/packages/meteoswiss-mcp/CHANGELOG.md
+++ b/packages/meteoswiss-mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # meteoswiss-mcp
 
+## 2.3.2
+
+### Patch Changes
+
+- 7eb1e59: Restore ChatGPT Deep Research / Connectors compatibility for the `fetch` tool. The v2.3.1 release renamed the `fetch` argument from `id` to `url`, which broke the canonical contract that ChatGPT (and the OpenAI Responses API Deep Research models) expects. This release renames it back to `id`, adds the canonical `text` and top-level `url` fields to the `fetch` response, keeps `content` as a back-compat alias of `text`, and adds an integration test suite + tool-manifest snapshot to prevent the regression from recurring. See `docs/plans/2026-04-19-chatgpt-fetch-compat.md` for the full investigation and references.
+
 ## 2.3.1
 
 ### Patch Changes

--- a/packages/meteoswiss-mcp/package.json
+++ b/packages/meteoswiss-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meteoswiss-mcp",
   "mcpName": "io.github.eins78/meteoswiss-mcp",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "MCP server for MeteoSwiss weather data — forecasts, real-time measurements, stations, pollen.",
   "license": "CC0-1.0",
   "author": "Max F. Albrecht <1@178.is>",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,97 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 10.33.0
+        version: 10.33.0
+      pnpm:
+        specifier: 10.33.0
+        version: 10.33.0
+
+packages:
+
+  '@pnpm/exe@10.33.0':
+    resolution: {integrity: sha512-sGsjztJBelzVMd0RhceDJ3p8Hk7eBcpu4G/TF6REzIvNdkKyxDT0czc1BWyo8Kbg+U0OBtK/TAGXN7Art4rTdg==}
+    hasBin: true
+
+  '@pnpm/linux-arm64@10.33.0':
+    resolution: {integrity: sha512-oYb5NxEyImqaTkLVX/7jL59m9Vfmd07iLWzr4Pg2LIk4XEtAllNcnksNHcp5Uf+lFk/BggtpOdvC84TG3VnbFw==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@pnpm/linux-x64@10.33.0':
+    resolution: {integrity: sha512-JYD2GXDF2roKpvTg5s032lYcUcT9lMedYlzxoqitWTjKlkMhl2gXRYpiDHdi2mWC5nFOJYlgYbUuy6jh3rXhng==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  '@pnpm/macos-arm64@10.33.0':
+    resolution: {integrity: sha512-3w9Pqpw0swnAbnEdAKumMuKj+TPaGratnqC49bC41vjR1pNs0UMwVdOxiIROUMQy5OHKPx0IH/wOOP0hkhJd+g==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@pnpm/macos-x64@10.33.0':
+    resolution: {integrity: sha512-SBeiLjU/9ORMIXAMsD6+Ltaaesniwh49FeFcG6kA64Zxr30U9SyzeZDnNOyWCGFjHeCmGfzCnSpNEN4VNo827g==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@pnpm/win-arm64@10.33.0':
+    resolution: {integrity: sha512-8X3NQqmfNVZ+dCu+EfD7ZkAgDgIKKdAgBBKcvhvMoMJq/nWHOfqDLxewE9TQ7qzVLuUKG/9b/xBVRVjdtDOm0w==}
+    cpu: [arm64]
+    os: [win32]
+    hasBin: true
+
+  '@pnpm/win-x64@10.33.0':
+    resolution: {integrity: sha512-wiPVvxmTuB6FFn+rZ4FfSk1WTn+cxiQ7MTJEEz1k9VZLN/yZujGrv/WLYH2JcwzVTgObfmQuBKeNgEUavEL0Qg==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  pnpm@10.33.0:
+    resolution: {integrity: sha512-EFaLtKavtYyes2MNqQzJUWQXq+vT+rvmc58K55VyjaFJHp21pUTHatjrdXD1xLs9bGN7LLQb/c20f6gjyGSTGQ==}
+    engines: {node: '>=18.12'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe@10.33.0':
+    optionalDependencies:
+      '@pnpm/linux-arm64': 10.33.0
+      '@pnpm/linux-x64': 10.33.0
+      '@pnpm/macos-arm64': 10.33.0
+      '@pnpm/macos-x64': 10.33.0
+      '@pnpm/win-arm64': 10.33.0
+      '@pnpm/win-x64': 10.33.0
+
+  '@pnpm/linux-arm64@10.33.0':
+    optional: true
+
+  '@pnpm/linux-x64@10.33.0':
+    optional: true
+
+  '@pnpm/macos-arm64@10.33.0':
+    optional: true
+
+  '@pnpm/macos-x64@10.33.0':
+    optional: true
+
+  '@pnpm/win-arm64@10.33.0':
+    optional: true
+
+  '@pnpm/win-x64@10.33.0':
+    optional: true
+
+  pnpm@10.33.0: {}
+
+---
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
This PR was manually created because the automated `version-packages.yml` workflow cannot open pull requests (`GitHub Actions is not permitted to create or approve pull requests`). The bot successfully pushed the version-bump commit to `changeset-release/main`; this PR merges that into `main`.

Same pattern as #87.

## Releases

### meteoswiss-mcp 2.3.1 → 2.3.2 (patch)

Restores ChatGPT Deep Research / Connectors compatibility for the `fetch` tool (regression introduced in 2.3.1). See #89 and `docs/plans/2026-04-19-chatgpt-fetch-compat.md` for full context.

- `fetch` argument renamed back to canonical `id`
- Response includes canonical `text` (+ top-level `url`); `content` kept as back-compat alias
- Adds integration test suite + tool-manifest snapshot to prevent regression

---

Merging this PR bumps `packages/meteoswiss-mcp/package.json` to 2.3.2 on `main`. Create the GitHub Release `meteoswiss-mcp-v2.3.2` afterwards to trigger `release.yml` (npm + GHCR publish).
