### PR TITLE
feat(meteoswiss-mcp): expose hourly precipitation in getLocalForecast

### DIFF
--- a/.changeset/hourly-precip-forecast.md
+++ b/.changeset/hourly-precip-forecast.md
@@ -1,0 +1,5 @@
+---
+"meteoswiss-mcp": minor
+---
+
+Add hourly precipitation breakdown to `meteoswissLocalForecast`. Each day's `precipitation` object now includes `hourly: Array<{ time, value }> | null` — per-hour mm readings in local Europe/Zurich time (DST-aware), letting consumers judge *when* rain is expected rather than only the daily total. Available for postal codes and mountain points; `null` for weather stations (not yet fetched for that point type).

--- a/docs/sessionlogs/2026-07-09-hourly-precipitation-forecast.md
+++ b/docs/sessionlogs/2026-07-09-hourly-precipitation-forecast.md
@@ -34,6 +34,17 @@ already reads it as local. Surfacing UTC-Z hourly times next to that field would
 *inconsistent* choice, and the feature's entire value proposition (commute planning) is
 inherently local-time-sensitive anyway. Landed on:
 
+> **Correction (post-PR review):** the premise "`date` already reads as local" turned out to be
+> literally false at the time — `date` was computed via `timestampToDate()` on the raw UTC
+> digits, with no timezone conversion, so it was actually a **UTC calendar day** wearing a
+> local-looking label. GitHub Copilot's automated PR review caught the resulting bug (see
+> "Copilot review fixes" below): an hour like `202603282300` UTC is `2026-03-29T00:00:00+01:00`
+> locally, yet was being bucketed under the UTC-dated `"2026-03-28"` day object — an hourly
+> entry whose own timestamp read "the 29th" nested inside a day literally labeled "the 28th".
+> The *decision* to use local time for `time` was still correct (approved by Max, and the
+> feature is inherently local-time-sensitive) — the fix was to make `date`'s bucketing live up
+> to the premise, not to abandon it. See below.
+
 - `time` = fully-qualified ISO 8601 with offset, e.g. `2026-03-28T09:00:00+01:00`.
 - Implemented via a module-level `Intl.DateTimeFormat` (`timeZone: 'Europe/Zurich'`,
   `timeZoneName: 'longOffset'`, `hourCycle: 'h23'`) — no new dependency, Node 22 ships full ICU.
@@ -89,10 +100,48 @@ pre-existing skip (documented macOS port-mapping flake, unrelated).
 - Commit `92c6337` on branch `worktree-hourly-precip`, pushed to origin.
 - GitHub issue #98 filed with problem statement, finding, proposed shape, and station-gap
   follow-up.
-- No PR opened yet — left for Max to open (or request in a follow-up session).
+- PR #99 opened (`Part of #98`, no closing keyword — #98 stays open for the station follow-up).
+
+## Copilot review fixes
+
+GitHub's automated Copilot PR review on #99 found two real issues, both fixed:
+
+1. **Misleading doc comment.** The schema JSDoc said an empty `hourly` array means "no rain
+   fell." Wrong — zero-mm hours are kept, not dropped, so a dry day still returns a 24-entry
+   array of `value: 0.0`. `[]` actually means "no hourly data at all for that day." Reworded.
+
+2. **UTC/local day-boundary mismatch (real bug, not a nitpick).** As detailed in the timezone
+   correction above: `date` was UTC-calendar-day-keyed while `time` was local Europe/Zurich —
+   so an hour close to local midnight could show a local calendar date one day ahead of the
+   `date` field it was nested under. Consulted the advisor before fixing: the right call was to
+   fix forward (make bucketing local-Zurich-consistent throughout) rather than retreat to UTC
+   timestamps, since Max had already approved local time and the PR wouldn't merge without his
+   review regardless — a concrete diff is a better artifact for him to react to than a paused
+   question.
+
+   Fix: added `zurichParts()`/`utcTimestampToZurichDate()` and switched **both** `groupByDate`
+   (temperature) and `groupPrecipByDate` (precipitation) — plus `pickDaytimeIcon`'s day-match
+   check — from UTC-date to local-Zurich-date bucketing, for non-station forecasts. Left the
+   midday-hour icon heuristic (`hour >= 7 && hour <= 13`) as UTC on purpose — it only picks a
+   representative icon and still lands near local midday within a local-day bucket; changing it
+   added risk for no benefit. Station forecasts (`buildStationForecast`) untouched — out of scope,
+   already daily-native.
+
+   **Consequence worth flagging:** this changes the day-boundary definition for **all**
+   non-station forecast fields (temperature min/max, weather icon — not just the new hourly
+   precipitation), shifting from UTC calendar days to local Zurich calendar days. That's broader
+   than "add precip," and is called out in the PR body for Max to scope down on review if he
+   disagrees. Verified against the fixture (which conveniently spans the CET→CEST transition)
+   that this doesn't change existing exact-value test outcomes: the day-1 total stayed 1.7mm and
+   the DST-boundary assertions still passed, because only the last (0mm) hour of day 1 moved to
+   day 2 — added a dedicated regression test asserting every hourly entry's local date matches
+   its containing day, and that the boundary hour lands in day 2.
+
+Re-ran `pnpm run ci` after both fixes — still 21 suites, 175 passed, 1 pre-existing skip.
 
 ## Pending / follow-ups
 
 - [ ] Fetch `rre150h0` for stations (`point_type_id === 1`) + add a station hourly fixture to
       close the station gap noted in #98.
-- [ ] Open the PR from `worktree-hourly-precip` to `main`.
+- [ ] PR #99 open, not merged — awaiting Max's review, including the day-boundary consequence
+      flagged above.

--- a/docs/sessionlogs/2026-07-09-hourly-precipitation-forecast.md
+++ b/docs/sessionlogs/2026-07-09-hourly-precipitation-forecast.md
@@ -1,0 +1,98 @@
+# Hourly Precipitation in getLocalForecast
+
+**Date:** 2026-07-09
+**Model:** Claude Opus 4.8 (worktree `hourly-precip`, branch `worktree-hourly-precip`)
+**Ticket:** [#98](https://github.com/eins78/meteoswiss-llm-tools/issues/98)
+
+## Motivation
+
+`meteoswissLocalForecast` only returned daily precipitation totals. Daily totals hide *when*
+rain falls, which is often more decision-relevant than the total (biking to work at 08:00 vs.
+rain arriving at 22:00 are very different situations for the same "3mm" day).
+
+## Key finding (verified before any implementation)
+
+The hourly data was **already being fetched and discarded**. In
+`src/data/ogd-local-forecast.ts`, non-station points (postal codes, mountain points) fetch
+`HOURLY_PARAMS = ['tre200h0', 'rre150h0', 'jww003i0']`. `rre150h0` is hourly precipitation in
+mm — confirmed against the fixture (`test/__fixtures__/ogd/forecasts/rre150h0.csv`, one value
+per hour, 00:00–23:00). The old `buildHourlyAggregatedForecast()` summed these into the daily
+total via `groupByDate()`, which strips timestamps — so the per-hour breakdown was thrown away
+immediately after being computed. This meant the feature required **no new data source or
+fixture** for the happy path — just retaining what was already in memory.
+
+## Decisions and rationale (the non-obvious part)
+
+### Timezone: local Europe/Zurich with UTC offset, not UTC
+
+Initial instinct was to stay consistent with the codebase's internal use of UTC (`todayUtc()`,
+`YYYYMMDDhhmm` timestamps, the `pickDaytimeIcon` "07-13 UTC ≈ 09-15 CET" comment). Consulted
+the advisor tool before committing to this, which reframed the consistency argument: the
+**output contract**, not the internal grouping machinery, is what a new field must match. The
+sibling `date` field (`"2026-03-28"`) is a bare date with no timezone marker — every consumer
+already reads it as local. Surfacing UTC-Z hourly times next to that field would have been the
+*inconsistent* choice, and the feature's entire value proposition (commute planning) is
+inherently local-time-sensitive anyway. Landed on:
+
+- `time` = fully-qualified ISO 8601 with offset, e.g. `2026-03-28T09:00:00+01:00`.
+- Implemented via a module-level `Intl.DateTimeFormat` (`timeZone: 'Europe/Zurich'`,
+  `timeZoneName: 'longOffset'`, `hourCycle: 'h23'`) — no new dependency, Node 22 ships full ICU.
+- Verified DST correctness with a throwaway script before writing any test assertions: the
+  fixture data happens to span 2026-03-28 → 2026-03-29, and 2026-03-29 is the CET→CEST
+  spring-forward in Switzerland. Confirmed the offset flips from `+01:00` to `+02:00` at UTC
+  01:00 that day (02:00 local is skipped). This let the integration test assert the DST
+  transition directly instead of just checking "a string came back."
+
+### `total` and `hourly` must derive from the same list
+
+Rewrote `buildHourlyAggregatedForecast` so the per-day `{time, value}[]` array is built first
+(new `groupPrecipByDate` helper, replacing the old `groupByDate` call for precip — `groupByDate`
+is retained only for temperature), and `total = round(sum(hourly values) * 10) / 10` is computed
+from that same array. Prevents the two fields from silently diverging in a future edit.
+
+### Stations: ship the gap, don't silently omit it
+
+Stations (`point_type_id === 1`) use `DAILY_PARAMS` and never fetch `rre150h0`. Rather than
+fetch it now (would need a new station hourly fixture, and no way to verify live station data
+offline), stations report `precipitation.hourly: null` — explicitly distinct from `[]` (dry but
+available). The gap is documented in the GitHub ticket as an explicit follow-up, not silently
+dropped.
+
+### Schema shape
+
+`precipitation: { total, unit, hourly: Array<{time, value}> | null }` — nested under the
+existing precipitation block rather than a new top-level array, so the breakdown sits next to
+the total it explains. Output type is a plain TS type (not Zod-validated at the tool boundary,
+consistent with the existing `DailyForecast`/`LocalForecastResponse` types).
+
+## Implementation
+
+- `src/schemas/ogd-local-forecast.ts`: added `HourlyPrecip` type; extended `DailyForecast`.
+- `src/data/ogd-local-forecast.ts`: added `zurichFormatter` + `utcTimestampToZurichIso()`;
+  added `groupPrecipByDate()`; reworked `buildHourlyAggregatedForecast()` precip handling;
+  `buildStationForecast()` now sets `hourly: null` explicitly.
+- `src/server.ts`: updated the `meteoswissLocalForecast` tool description to mention the new
+  field and the station limitation.
+- `test/integration/ogd-local-forecast.test.ts`: extended the postal-code test with exact-value
+  assertions (not just shape) for a known rainy hour, a `total`-matches-`sum(hourly)` check, and
+  a dedicated DST-boundary test asserting both `+01:00` and `+02:00` offsets appear across the
+  fixture's day-2 series. Station test now asserts `hourly === null`.
+- `.changeset/hourly-precip-forecast.md`: minor bump (additive, backward-compatible).
+
+## Verification
+
+`pnpm run ci` (tsc lint + eslint + build + full jest suite) — 21 suites, 175 passed, 1
+pre-existing skip (documented macOS port-mapping flake, unrelated).
+
+## Result
+
+- Commit `92c6337` on branch `worktree-hourly-precip`, pushed to origin.
+- GitHub issue #98 filed with problem statement, finding, proposed shape, and station-gap
+  follow-up.
+- No PR opened yet — left for Max to open (or request in a follow-up session).
+
+## Pending / follow-ups
+
+- [ ] Fetch `rre150h0` for stations (`point_type_id === 1`) + add a station hourly fixture to
+      close the station gap noted in #98.
+- [ ] Open the PR from `worktree-hourly-precip` to `main`.

--- a/packages/meteoswiss-mcp/src/data/ogd-local-forecast.ts
+++ b/packages/meteoswiss-mcp/src/data/ogd-local-forecast.ts
@@ -17,6 +17,7 @@ import type {
   GetLocalForecastParams,
   LocalForecastResponse,
   DailyForecast,
+  HourlyPrecip,
 } from '../schemas/ogd-local-forecast.js';
 import type { StacItem } from '../schemas/ogd-shared.js';
 
@@ -42,6 +43,42 @@ function findLatestAssetKey(item: StacItem, param: string): string | null {
  */
 function timestampToDate(ts: string): string {
   return `${ts.slice(0, 4)}-${ts.slice(4, 6)}-${ts.slice(6, 8)}`;
+}
+
+/**
+ * Formatter that renders a UTC instant as local Europe/Zurich wall-clock time
+ * plus its UTC offset (DST-aware). Reused across calls since constructing an
+ * `Intl.DateTimeFormat` repeatedly is comparatively expensive.
+ */
+const zurichFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'Europe/Zurich',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hourCycle: 'h23',
+  timeZoneName: 'longOffset',
+});
+
+/**
+ * Convert a MeteoSwiss UTC timestamp (YYYYMMDDhhmm) to an ISO 8601 string in
+ * local Europe/Zurich time with UTC offset, DST-correct
+ * (e.g. "202603280800" -> "2026-03-28T09:00:00+01:00").
+ */
+function utcTimestampToZurichIso(ts: string): string {
+  const utcMs = Date.UTC(
+    Number(ts.slice(0, 4)),
+    Number(ts.slice(4, 6)) - 1,
+    Number(ts.slice(6, 8)),
+    Number(ts.slice(8, 10)),
+    Number(ts.slice(10, 12))
+  );
+  const parts = zurichFormatter.formatToParts(new Date(utcMs));
+  const get = (type: string): string => parts.find((p) => p.type === type)?.value ?? '';
+  const offset = get('timeZoneName').replace('GMT', '');
+  return `${get('year')}-${get('month')}-${get('day')}T${get('hour')}:${get('minute')}:${get('second')}${offset}`;
 }
 
 /**
@@ -92,6 +129,8 @@ function buildStationForecast(
       precipitation: {
         total: dateKeyed.get('rka150d0')?.get(date) ?? null,
         unit: 'mm',
+        // Stations use daily params (rka150d0) — hourly precip isn't fetched for them yet.
+        hourly: null,
       },
     };
   });
@@ -107,6 +146,25 @@ function groupByDate(hourlyMap: Map<string, number | null>): Map<string, number[
     const date = timestampToDate(ts);
     const existing = byDate.get(date) ?? [];
     existing.push(val);
+    byDate.set(date, existing);
+  }
+  return byDate;
+}
+
+/**
+ * Group hourly precipitation values by UTC date, converting each timestamp to
+ * local Europe/Zurich time. Within each day, entries are sorted chronologically
+ * and null/missing readings are skipped (zero-mm hours are kept).
+ */
+function groupPrecipByDate(hourlyMap: Map<string, number | null>): Map<string, HourlyPrecip[]> {
+  const byDate = new Map<string, HourlyPrecip[]>();
+  const sortedTimestamps = [...hourlyMap.keys()].sort();
+  for (const ts of sortedTimestamps) {
+    const val = hourlyMap.get(ts) ?? null;
+    if (val === null) continue;
+    const date = timestampToDate(ts);
+    const existing = byDate.get(date) ?? [];
+    existing.push({ time: utcTimestampToZurichIso(ts), value: val });
     byDate.set(date, existing);
   }
   return byDate;
@@ -163,7 +221,7 @@ function buildHourlyAggregatedForecast(
   const hourlyIcon = paramData.get('jww003i0') ?? new Map<string, number | null>();
 
   const tempByDate = groupByDate(hourlyTemp);
-  const precipByDate = groupByDate(hourlyPrecip);
+  const precipByDate = groupPrecipByDate(hourlyPrecip);
 
   const today = todayUtc();
   const dates = [...tempByDate.keys()]
@@ -172,9 +230,11 @@ function buildHourlyAggregatedForecast(
     .slice(0, days);
   return dates.map((date) => {
     const temps = tempByDate.get(date) ?? [];
-    const precips = precipByDate.get(date) ?? [];
+    // Derive both the daily total and the hourly series from the same list so
+    // they cannot disagree with each other.
+    const hourly = precipByDate.get(date) ?? [];
     const precipTotal =
-      precips.length > 0 ? Math.round(precips.reduce((a, b) => a + b, 0) * 10) / 10 : null;
+      hourly.length > 0 ? Math.round(hourly.reduce((sum, h) => sum + h.value, 0) * 10) / 10 : null;
     const iconCode = pickDaytimeIcon(hourlyIcon, date);
 
     return {
@@ -184,7 +244,7 @@ function buildHourlyAggregatedForecast(
         max: temps.length > 0 ? Math.max(...temps) : null,
         unit: '\u00B0C',
       },
-      precipitation: { total: precipTotal, unit: 'mm' },
+      precipitation: { total: precipTotal, unit: 'mm', hourly },
       weather: iconCode !== null ? weatherIconDescription(iconCode) : null,
       weather_icon_url: iconCode !== null ? weatherIconUrl(iconCode) : null,
     };

--- a/packages/meteoswiss-mcp/src/data/ogd-local-forecast.ts
+++ b/packages/meteoswiss-mcp/src/data/ogd-local-forecast.ts
@@ -63,11 +63,9 @@ const zurichFormatter = new Intl.DateTimeFormat('en-US', {
 });
 
 /**
- * Convert a MeteoSwiss UTC timestamp (YYYYMMDDhhmm) to an ISO 8601 string in
- * local Europe/Zurich time with UTC offset, DST-correct
- * (e.g. "202603280800" -> "2026-03-28T09:00:00+01:00").
+ * Render a UTC timestamp's local Europe/Zurich date and wall-clock time, DST-correct.
  */
-function utcTimestampToZurichIso(ts: string): string {
+function zurichParts(ts: string): { date: string; time: string; offset: string } {
   const utcMs = Date.UTC(
     Number(ts.slice(0, 4)),
     Number(ts.slice(4, 6)) - 1,
@@ -77,8 +75,21 @@ function utcTimestampToZurichIso(ts: string): string {
   );
   const parts = zurichFormatter.formatToParts(new Date(utcMs));
   const get = (type: string): string => parts.find((p) => p.type === type)?.value ?? '';
-  const offset = get('timeZoneName').replace('GMT', '');
-  return `${get('year')}-${get('month')}-${get('day')}T${get('hour')}:${get('minute')}:${get('second')}${offset}`;
+  return {
+    date: `${get('year')}-${get('month')}-${get('day')}`,
+    time: `${get('hour')}:${get('minute')}:${get('second')}`,
+    offset: get('timeZoneName').replace('GMT', ''),
+  };
+}
+
+/**
+ * Convert a MeteoSwiss UTC timestamp (YYYYMMDDhhmm) to its local Europe/Zurich
+ * calendar date (YYYY-MM-DD), DST-correct. Used to bucket hourly readings into
+ * days that match the local wall-clock times we surface, so a day's `hourly`
+ * entries never spill across the local midnight boundary into a neighboring day.
+ */
+function utcTimestampToZurichDate(ts: string): string {
+  return zurichParts(ts).date;
 }
 
 /**
@@ -137,13 +148,15 @@ function buildStationForecast(
 }
 
 /**
- * Group hourly values by date.
+ * Group hourly values by local Europe/Zurich date. Non-station forecasts are
+ * bucketed by local day (not the raw UTC date) so that a day's data matches the
+ * local-time labels we surface elsewhere (see `utcTimestampToZurichDate`).
  */
 function groupByDate(hourlyMap: Map<string, number | null>): Map<string, number[]> {
   const byDate = new Map<string, number[]>();
   for (const [ts, val] of hourlyMap.entries()) {
     if (val === null) continue;
-    const date = timestampToDate(ts);
+    const date = utcTimestampToZurichDate(ts);
     const existing = byDate.get(date) ?? [];
     existing.push(val);
     byDate.set(date, existing);
@@ -152,9 +165,10 @@ function groupByDate(hourlyMap: Map<string, number | null>): Map<string, number[
 }
 
 /**
- * Group hourly precipitation values by UTC date, converting each timestamp to
- * local Europe/Zurich time. Within each day, entries are sorted chronologically
- * and null/missing readings are skipped (zero-mm hours are kept).
+ * Group hourly precipitation values by local Europe/Zurich date — the same day
+ * boundary used for `groupByDate` — so every entry's `time` falls within the day
+ * it's nested under. Within each day, entries are sorted chronologically and
+ * null/missing readings are skipped (zero-mm hours are kept).
  */
 function groupPrecipByDate(hourlyMap: Map<string, number | null>): Map<string, HourlyPrecip[]> {
   const byDate = new Map<string, HourlyPrecip[]>();
@@ -162,9 +176,9 @@ function groupPrecipByDate(hourlyMap: Map<string, number | null>): Map<string, H
   for (const ts of sortedTimestamps) {
     const val = hourlyMap.get(ts) ?? null;
     if (val === null) continue;
-    const date = timestampToDate(ts);
+    const { date, time, offset } = zurichParts(ts);
     const existing = byDate.get(date) ?? [];
-    existing.push({ time: utcTimestampToZurichIso(ts), value: val });
+    existing.push({ time: `${date}T${time}${offset}`, value: val });
     byDate.set(date, existing);
   }
   return byDate;
@@ -172,6 +186,7 @@ function groupPrecipByDate(hourlyMap: Map<string, number | null>): Map<string, H
 
 /**
  * Pick the most representative weather icon for a day.
+ * `date` is a local Europe/Zurich calendar date (see `utcTimestampToZurichDate`).
  * Prefers midday hours (09-15 local, ~07-13 UTC) for daytime representation.
  * Falls back to the most frequent icon code if no midday data.
  */
@@ -179,7 +194,7 @@ function pickDaytimeIcon(entries: Map<string, number | null>, date: string): num
   const dayEntries: Array<{ hour: number; code: number }> = [];
   for (const [ts, val] of entries.entries()) {
     if (val === null) continue;
-    if (timestampToDate(ts) !== date) continue;
+    if (utcTimestampToZurichDate(ts) !== date) continue;
     const hour = Number(ts.slice(8, 10));
     dayEntries.push({ hour, code: val });
   }

--- a/packages/meteoswiss-mcp/src/schemas/ogd-local-forecast.ts
+++ b/packages/meteoswiss-mcp/src/schemas/ogd-local-forecast.ts
@@ -22,13 +22,30 @@ export const GetLocalForecastParamsSchema = z.object({
 });
 export type GetLocalForecastParams = z.infer<typeof GetLocalForecastParamsSchema>;
 
+/** A single hourly precipitation reading within a day */
+export type HourlyPrecip = {
+  /** ISO 8601 timestamp with UTC offset, in local Europe/Zurich time (e.g. "2026-03-28T09:00:00+01:00") */
+  time: string;
+  /** Precipitation sum for that hour, in mm */
+  value: number;
+};
+
 /** Daily forecast summary for one day */
 export type DailyForecast = {
   date: string;
   weather: string | null;
   weather_icon_url: string | null;
   temperature: { min: number | null; max: number | null; unit: string };
-  precipitation: { total: number | null; unit: string };
+  precipitation: {
+    total: number | null;
+    unit: string;
+    /**
+     * Per-hour precipitation breakdown, local Europe/Zurich time.
+     * `null` when not available for this location's point type (currently: weather stations).
+     * An empty array means the breakdown is available but no rain fell.
+     */
+    hourly: HourlyPrecip[] | null;
+  };
 };
 
 /** Full forecast response */

--- a/packages/meteoswiss-mcp/src/schemas/ogd-local-forecast.ts
+++ b/packages/meteoswiss-mcp/src/schemas/ogd-local-forecast.ts
@@ -32,6 +32,7 @@ export type HourlyPrecip = {
 
 /** Daily forecast summary for one day */
 export type DailyForecast = {
+  /** Local Europe/Zurich calendar date (YYYY-MM-DD) for postal codes/mountain points; the station data source's native daily date for weather stations. */
   date: string;
   weather: string | null;
   weather_icon_url: string | null;
@@ -40,9 +41,11 @@ export type DailyForecast = {
     total: number | null;
     unit: string;
     /**
-     * Per-hour precipitation breakdown, local Europe/Zurich time.
-     * `null` when not available for this location's point type (currently: weather stations).
-     * An empty array means the breakdown is available but no rain fell.
+     * Per-hour precipitation breakdown, keyed to the local Europe/Zurich calendar
+     * day this `date` represents (each entry's `time` always falls within this day).
+     * `null` when not available for this location's point type (currently: weather
+     * stations). A dry day still returns a non-empty array — 0mm hours are kept, not
+     * omitted; an empty array means no hourly readings were available for the day at all.
      */
     hourly: HourlyPrecip[] | null;
   };

--- a/packages/meteoswiss-mcp/src/server.ts
+++ b/packages/meteoswiss-mcp/src/server.ts
@@ -161,9 +161,17 @@ Coverage: ~6000 Swiss locations (all postal codes + weather stations + mountain 
 Forecast horizon: up to 9 days. Updated hourly.
 
 For postal codes and mountain points, each day also includes an hourly precipitation
-breakdown (precipitation.hourly, local Europe/Zurich time) — useful for judging *when*
-rain is expected, not just the daily total. Not yet available for weather stations
-(precipitation.hourly is null there).`,
+breakdown (precipitation.hourly) — useful for judging *when* rain is expected, not just
+the daily total:
+- Each entry's "time" is already local wall-clock time for the location (Europe/Zurich),
+  with the UTC offset included, e.g. "2026-07-09T14:00:00+02:00". It is NOT UTC — do not
+  convert it.
+- A dry hour is reported as value: 0, not omitted. A fully dry day is still a full array
+  of zero-value hours, not an empty array.
+- precipitation.hourly is null when no hourly breakdown exists for this location at all
+  (weather stations only have a daily total, precipitation.total).
+- precipitation.hourly is [] (empty array) only for postal codes/mountain points where
+  hourly readings are missing for that specific day (a data gap) — distinct from null.`,
     GetLocalForecastParamsSchema.shape,
     async (params: GetLocalForecastParams) => {
       const _t0 = performance.now();

--- a/packages/meteoswiss-mcp/src/server.ts
+++ b/packages/meteoswiss-mcp/src/server.ts
@@ -158,7 +158,12 @@ Accepts:
 - Place names: "Zurich", "Basel", "Lugano"
 
 Coverage: ~6000 Swiss locations (all postal codes + weather stations + mountain points).
-Forecast horizon: up to 9 days. Updated hourly.`,
+Forecast horizon: up to 9 days. Updated hourly.
+
+For postal codes and mountain points, each day also includes an hourly precipitation
+breakdown (precipitation.hourly, local Europe/Zurich time) — useful for judging *when*
+rain is expected, not just the daily total. Not yet available for weather stations
+(precipitation.hourly is null there).`,
     GetLocalForecastParamsSchema.shape,
     async (params: GetLocalForecastParams) => {
       const _t0 = performance.now();

--- a/packages/meteoswiss-mcp/test/integration/ogd-local-forecast.test.ts
+++ b/packages/meteoswiss-mcp/test/integration/ogd-local-forecast.test.ts
@@ -83,6 +83,13 @@ describe('meteoswissLocalForecast Tool', () => {
     expect(day1.precipitation.total).toBe(summed);
     expect(day1.precipitation.total).toBe(1.7);
 
+    // Every hourly entry's local calendar date must match the day it's nested
+    // under. UTC 202603282300 is local 2026-03-29T00:00:00+01:00 — it must be
+    // attributed to day2, not day1, even though its raw timestamp says "28".
+    for (const h of day1.precipitation.hourly) {
+      expect(h.time.slice(0, 10)).toBe('2026-03-28');
+    }
+
     // Fixture crosses the CET->CEST spring-forward (2026-03-29, 02:00 local).
     // Day 2 must contain readings on both sides of the DST boundary.
     const day2 = data.forecast.find((d: { date: string }) => d.date === '2026-03-29');
@@ -92,6 +99,14 @@ describe('meteoswissLocalForecast Tool', () => {
     );
     expect(offsets.has('+01:00')).toBe(true);
     expect(offsets.has('+02:00')).toBe(true);
+    for (const h of day2.precipitation.hourly) {
+      expect(h.time.slice(0, 10)).toBe('2026-03-29');
+    }
+    // The UTC 23:00-on-the-28th reading (local midnight of the 29th) must land here.
+    expect(day2.precipitation.hourly).toContainEqual({
+      time: '2026-03-29T00:00:00+01:00',
+      value: 0.0,
+    });
     expect(day2.precipitation.hourly).toContainEqual({
       time: '2026-03-29T01:00:00+01:00',
       value: 0.0,

--- a/packages/meteoswiss-mcp/test/integration/ogd-local-forecast.test.ts
+++ b/packages/meteoswiss-mcp/test/integration/ogd-local-forecast.test.ts
@@ -54,6 +54,54 @@ describe('meteoswissLocalForecast Tool', () => {
     expect(day.weather_icon_url).toMatch(/^https:\/\/www\.meteoschweiz\.admin\.ch\/static\/resources\/weather-symbols\/\d+\.svg$/);
   });
 
+  it('returns an hourly precipitation breakdown for a postal code, in local Zurich time', async () => {
+    const result = await client.callTool('meteoswissLocalForecast', {
+      location: '8001',
+      days: 2,
+    });
+
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse(result.content[0].text);
+
+    // Fixture (rre150h0.csv, point 800100) day 2026-03-28: 06:00-09:00 UTC carry
+    // rain (0.1/0.3/0.5/0.2 mm), the rest of the day is dry. Assert the exact
+    // series content — not just array shape — per the fixture's known values.
+    const day1 = data.forecast.find((d: { date: string }) => d.date === '2026-03-28');
+    expect(day1).toBeDefined();
+    expect(Array.isArray(day1.precipitation.hourly)).toBe(true);
+    expect(day1.precipitation.hourly.length).toBeGreaterThan(0);
+    expect(day1.precipitation.hourly).toContainEqual({
+      time: '2026-03-28T09:00:00+01:00',
+      value: 0.5,
+    });
+    // The daily total must be derivable from (i.e. consistent with) the hourly series.
+    const summed =
+      Math.round(
+        day1.precipitation.hourly.reduce((sum: number, h: { value: number }) => sum + h.value, 0) *
+          10
+      ) / 10;
+    expect(day1.precipitation.total).toBe(summed);
+    expect(day1.precipitation.total).toBe(1.7);
+
+    // Fixture crosses the CET->CEST spring-forward (2026-03-29, 02:00 local).
+    // Day 2 must contain readings on both sides of the DST boundary.
+    const day2 = data.forecast.find((d: { date: string }) => d.date === '2026-03-29');
+    expect(day2).toBeDefined();
+    const offsets = new Set(
+      day2.precipitation.hourly.map((h: { time: string }) => h.time.slice(-6))
+    );
+    expect(offsets.has('+01:00')).toBe(true);
+    expect(offsets.has('+02:00')).toBe(true);
+    expect(day2.precipitation.hourly).toContainEqual({
+      time: '2026-03-29T01:00:00+01:00',
+      value: 0.0,
+    });
+    expect(day2.precipitation.hourly).toContainEqual({
+      time: '2026-03-29T03:00:00+02:00',
+      value: 0.0,
+    });
+  });
+
   it('should return forecast with weather_icon_url for a station', async () => {
     const result = await client.callTool('meteoswissLocalForecast', {
       location: 'Napf',
@@ -68,6 +116,9 @@ describe('meteoswissLocalForecast Tool', () => {
     expect(day.weather_icon_url).toMatch(
       /^https:\/\/www\.meteoschweiz\.admin\.ch\/static\/resources\/weather-symbols\/\d+\.svg$/
     );
+    // Stations don't fetch hourly precip params yet — hourly must be explicitly
+    // null, distinct from "available but empty".
+    expect(day.precipitation.hourly).toBeNull();
   });
 
   it('should return error for empty location', async () => {


### PR DESCRIPTION
## Summary

- Adds `precipitation.hourly: Array<{ time, value }> | null` to each day of `meteoswissLocalForecast`, so consumers can see *when* rain is expected, not just the daily total (biking to work at 08:00 vs. rain at 22:00 look identical today).
- No new data source: `rre150h0` (hourly precip, mm) was already fetched for postal codes/mountain points and summed into the daily total — this retains the per-hour series instead of discarding it after summation.
- `time` is local Europe/Zurich time with UTC offset (e.g. `2026-03-28T09:00:00+01:00`), DST-correct.
- Daily `precipitation.total` is unchanged in shape and now derived from the same per-hour list as `hourly`, so the two can't diverge.
- Weather stations (`point_type_id === 1`) report `precipitation.hourly: null` — they don't fetch hourly params yet; tracked as a follow-up in #98.

## Post-review fix: day boundary now local Zurich, not UTC (please review)

GitHub's Copilot auto-review caught a real bug: `date` was previously bucketed by the raw UTC
calendar day (no timezone conversion), while the new `time` field is local Europe/Zurich. Near
midnight this could show an hourly entry timestamped "the 29th" nested inside a day object
labeled `date: "2026-03-28"`.

Fixed by switching **all** non-station daily aggregation (temperature min/max, weather icon,
and precipitation) from UTC-calendar-day bucketing to **local Europe/Zurich-calendar-day**
bucketing — so `date` now consistently means "local day" the way the whole feature already
implied. Station forecasts are untouched (already daily-native, out of scope).

**This is broader than "add precip"** — it changes the day boundary for existing non-station
fields (temperature, icon), not just the new hourly precipitation. Flagging explicitly in case
you'd rather scope that down to precipitation-only for this PR and handle the temp/icon
boundary shift separately. I verified it doesn't change any existing exact-value test outcome
(added a regression test asserting hourly entries' local dates match their containing day).

## Test plan

- [x] `pnpm run ci` (tsc lint + eslint + build + full jest suite) — 21 suites, 175 passed, 1 pre-existing unrelated skip (documented macOS port-mapping flake)
- [x] Integration test asserts exact hourly values (not just array shape) against the fixture
- [x] Dedicated DST-boundary test: the fixture spans the 2026-03-29 CET→CEST spring-forward, and the test asserts both `+01:00` and `+02:00` offsets appear in that day's series
- [x] Regression test: every hourly entry's local calendar date matches the day it's nested under (the exact bug Copilot flagged)
- [x] Station path asserts `precipitation.hourly === null`
- [x] Changeset added (`meteoswiss-mcp`: minor — additive, backward-compatible)

Part of #98 (issue also tracks the station-hourly follow-up, left open).
