### PR TITLE
Round numeric measurements by unit at assembly

### DIFF
--- a/.changeset/round-numeric-measurements-by-unit.md
+++ b/.changeset/round-numeric-measurements-by-unit.md
@@ -1,0 +1,5 @@
+---
+"meteoswiss-mcp": minor
+---
+
+Round numeric measurement values in tool output by unit (e.g. temperature and wind to 1 decimal place) for cleaner, more consistent display. Coordinates, elevations, IDs, and timestamps are unaffected.

--- a/packages/meteoswiss-mcp/src/data/ogd-climate-data.ts
+++ b/packages/meteoswiss-mcp/src/data/ogd-climate-data.ts
@@ -6,6 +6,7 @@
 import { getLatin1CsvData } from './ogd-data-store.js';
 import { resolveNbcnStation, findNearestNbcnStation } from './ogd-nbcn-stations.js';
 import { parseNumeric } from '../support/ogd-csv-parser.js';
+import { roundOptional } from '../support/round-measurements.js';
 import { debugData } from '../support/logging.js';
 import { SOURCE_ATTRIBUTION } from '../schemas/ogd-shared.js';
 import type { CsvRow } from '../support/ogd-csv-parser.js';
@@ -55,22 +56,43 @@ function mapMeasurement(row: CsvRow): ClimateMeasurement {
   return {
     date: parseTimestamp(row.reference_timestamp ?? ''),
     // Temperature (available at all resolutions)
-    temperature_mean:
+    temperature_mean: roundOptional(
       parseNumeric(row.ths200d0 ?? row.ths200m0 ?? row.ths200y0 ?? null) ?? undefined,
-    temperature_max:
+      '°C'
+    ),
+    temperature_max: roundOptional(
       parseNumeric(row.ths200dx ?? row.ths2dymx ?? row.ths2dyyx ?? null) ?? undefined,
-    temperature_min:
+      '°C'
+    ),
+    temperature_min: roundOptional(
       parseNumeric(row.ths200dn ?? row.ths2dymn ?? row.ths2dyyn ?? null) ?? undefined,
+      '°C'
+    ),
     // Precipitation (monthly/yearly)
-    precipitation: parseNumeric(row.rhs150m0 ?? row.rhs150y0 ?? null) ?? undefined,
+    precipitation: roundOptional(
+      parseNumeric(row.rhs150m0 ?? row.rhs150y0 ?? null) ?? undefined,
+      'mm'
+    ),
     // Sunshine (monthly/yearly)
-    sunshine_duration_min: parseNumeric(row.shs000m0 ?? row.shs000y0 ?? null) ?? undefined,
+    sunshine_duration_min: roundOptional(
+      parseNumeric(row.shs000m0 ?? row.shs000y0 ?? null) ?? undefined,
+      'min'
+    ),
     // Radiation (monthly/yearly)
-    radiation_w_m2: parseNumeric(row.ghs000m0 ?? row.ghs000y0 ?? null) ?? undefined,
+    radiation_w_m2: roundOptional(
+      parseNumeric(row.ghs000m0 ?? row.ghs000y0 ?? null) ?? undefined,
+      'W/m²'
+    ),
     // Wind (monthly/yearly)
-    wind_speed_m_s: parseNumeric(row.fhs010m0 ?? row.fhs010y0 ?? null) ?? undefined,
+    wind_speed_m_s: roundOptional(
+      parseNumeric(row.fhs010m0 ?? row.fhs010y0 ?? null) ?? undefined,
+      'm/s'
+    ),
     // Pressure (monthly/yearly)
-    pressure_hpa: parseNumeric(row.phsstam0 ?? row.phsstay0 ?? null) ?? undefined,
+    pressure_hpa: roundOptional(
+      parseNumeric(row.phsstam0 ?? row.phsstay0 ?? null) ?? undefined,
+      'hPa'
+    ),
     // Day counts (monthly/yearly)
     frost_days: parseNumeric(row.ths00nm0 ?? row.ths00ny0 ?? null) ?? undefined,
     summer_days: parseNumeric(row.ths25xm0 ?? row.ths25xy0 ?? null) ?? undefined,

--- a/packages/meteoswiss-mcp/src/data/ogd-current-weather.ts
+++ b/packages/meteoswiss-mcp/src/data/ogd-current-weather.ts
@@ -6,6 +6,7 @@
 import { getCsvData, getLatin1CsvData } from './ogd-data-store.js';
 import { resolveSmnStation, loadSmnStations } from './ogd-smn-stations.js';
 import { parseNumeric } from '../support/ogd-csv-parser.js';
+import { roundByUnit } from '../support/round-measurements.js';
 import { reverseGeocodeSwiss } from '../support/reverse-geocode.js';
 import type { ReverseGeocodeResult } from '../support/reverse-geocode.js';
 import { debugData } from '../support/logging.js';
@@ -46,7 +47,7 @@ async function getCachedReverseGeocode(
 function measurement(row: CsvRow, key: string, unit: string): MeasurementValue | undefined {
   const val = parseNumeric(row[key] ?? null);
   if (val === null) return undefined;
-  return { value: val, unit };
+  return { value: roundByUnit(val, unit), unit };
 }
 
 /**
@@ -238,7 +239,7 @@ async function fetchVisualObservations(
 
     return {
       date,
-      cloud_cover_percent: cloudCover ?? undefined,
+      cloud_cover_percent: cloudCover === null ? undefined : roundByUnit(cloudCover, '%'),
       is_clear_day: parseFlag(latestRow.nto002d0 ?? null),
       is_overcast_day: parseFlag(latestRow.nto008d0 ?? null),
       has_rain: parseFlag(latestRow.w1p012d0 ?? null),

--- a/packages/meteoswiss-mcp/src/data/ogd-local-forecast.ts
+++ b/packages/meteoswiss-mcp/src/data/ogd-local-forecast.ts
@@ -9,6 +9,7 @@
 import { getLatestItem, resolveAssetUrl } from './ogd-stac-client.js';
 import { getCsvData } from './ogd-data-store.js';
 import { parseNumeric } from '../support/ogd-csv-parser.js';
+import { roundByUnit, roundNullable } from '../support/round-measurements.js';
 import { resolveForecastPoint } from './ogd-station-resolver.js';
 import { debugData } from '../support/logging.js';
 import { OGD_COLLECTIONS, pointTypeFromId, SOURCE_ATTRIBUTION } from '../schemas/ogd-shared.js';
@@ -133,12 +134,12 @@ function buildStationForecast(
       weather: iconCode !== null ? weatherIconDescription(iconCode) : null,
       weather_icon_url: iconCode !== null ? weatherIconUrl(iconCode) : null,
       temperature: {
-        min: dateKeyed.get('tre200dn')?.get(date) ?? null,
-        max: dateKeyed.get('tre200dx')?.get(date) ?? null,
+        min: roundNullable(dateKeyed.get('tre200dn')?.get(date) ?? null, '°C'),
+        max: roundNullable(dateKeyed.get('tre200dx')?.get(date) ?? null, '°C'),
         unit: '\u00B0C',
       },
       precipitation: {
-        total: dateKeyed.get('rka150d0')?.get(date) ?? null,
+        total: roundNullable(dateKeyed.get('rka150d0')?.get(date) ?? null, 'mm'),
         unit: 'mm',
         // Stations use daily params (rka150d0) — hourly precip isn't fetched for them yet.
         hourly: null,
@@ -178,7 +179,7 @@ function groupPrecipByDate(hourlyMap: Map<string, number | null>): Map<string, H
     if (val === null) continue;
     const { date, time, offset } = zurichParts(ts);
     const existing = byDate.get(date) ?? [];
-    existing.push({ time: `${date}T${time}${offset}`, value: val });
+    existing.push({ time: `${date}T${time}${offset}`, value: roundByUnit(val, 'mm') });
     byDate.set(date, existing);
   }
   return byDate;
@@ -249,14 +250,19 @@ function buildHourlyAggregatedForecast(
     // they cannot disagree with each other.
     const hourly = precipByDate.get(date) ?? [];
     const precipTotal =
-      hourly.length > 0 ? Math.round(hourly.reduce((sum, h) => sum + h.value, 0) * 10) / 10 : null;
+      hourly.length > 0
+        ? roundByUnit(
+            hourly.reduce((sum, h) => sum + h.value, 0),
+            'mm'
+          )
+        : null;
     const iconCode = pickDaytimeIcon(hourlyIcon, date);
 
     return {
       date,
       temperature: {
-        min: temps.length > 0 ? Math.min(...temps) : null,
-        max: temps.length > 0 ? Math.max(...temps) : null,
+        min: temps.length > 0 ? roundByUnit(Math.min(...temps), '°C') : null,
+        max: temps.length > 0 ? roundByUnit(Math.max(...temps), '°C') : null,
         unit: '\u00B0C',
       },
       precipitation: { total: precipTotal, unit: 'mm', hourly },

--- a/packages/meteoswiss-mcp/src/data/ogd-pollen-data.ts
+++ b/packages/meteoswiss-mcp/src/data/ogd-pollen-data.ts
@@ -6,6 +6,7 @@
 import { getCollection } from './ogd-stac-client.js';
 import { getLatin1CsvData } from './ogd-data-store.js';
 import { parseNumeric } from '../support/ogd-csv-parser.js';
+import { roundByUnit } from '../support/round-measurements.js';
 import { normalize } from '../support/normalize.js';
 import { debugData } from '../support/logging.js';
 import { OGD_COLLECTIONS, SOURCE_ATTRIBUTION } from '../schemas/ogd-shared.js';
@@ -142,7 +143,7 @@ export async function getPollenData(params: GetPollenDataParams): Promise<Pollen
           pollen.push({
             type: pollenDisplayName(prefix),
             status: 'measured',
-            value,
+            value: roundByUnit(value, 'particles/m\u00B3'),
             unit: 'particles/m\u00B3',
           });
         }

--- a/packages/meteoswiss-mcp/src/support/round-measurements.ts
+++ b/packages/meteoswiss-mcp/src/support/round-measurements.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit-aware rounding for numeric measurement values.
+ *
+ * Rounding is applied at each tool's data-assembly point (see the
+ * construction sites in `src/data/*.ts`), not as a post-hoc transform on the
+ * serialized response. Every numeric value in a tool response is genuinely
+ * parsed from CSV data and explicitly placed into a typed response object by
+ * our own code, so the natural place to round is where the value is first
+ * assembled — not a generic tree-walk applied afterward.
+ *
+ * {@link UNIT_DECIMALS} is the single source of truth for how many decimal
+ * places a given unit should be rounded to. {@link roundByUnit} applies it to
+ * a plain number; {@link roundNullable} and {@link roundOptional} are thin
+ * wrappers for the `number | null` and `number | undefined` shapes commonly
+ * produced by CSV parsing at assembly sites.
+ *
+ * Fields with no physical unit (coordinates, elevation, distance_km, climate
+ * day counts, IDs, timestamps, pagination counters) are never routed through
+ * these helpers and so pass through unchanged.
+ */
+
+/** Decimal places to round to, keyed by the exact unit string emitted in tool output. */
+export const UNIT_DECIMALS: Record<string, number> = {
+  '°C': 1,
+  'km/h': 1,
+  'm/s': 1,
+  mm: 1,
+  '°': 0,
+  '%': 0,
+  hPa: 0,
+  min: 0,
+  'W/m²': 0,
+  cm: 0,
+  'particles/m³': 0,
+};
+
+/**
+ * Rounds `value` to `decimals` places by shifting the decimal point through
+ * string/exponential notation rather than `value * 10 ** decimals`. Plain
+ * multiplication is susceptible to IEEE-754 representation error — e.g.
+ * `0.15 * 10 === 1.4999999999999998`, which `Math.round` would floor to `1`
+ * (giving `0.1` instead of the correct `0.2`). Parsing `'0.15e1'` sidesteps
+ * that specific artifact — it's the value you'd get from writing the shifted
+ * literal directly, without the extra rounding error `* 10` introduces —
+ * though it's still an IEEE-754 double under the hood, not infinite precision.
+ *
+ * Rounds the absolute value and restores the sign afterward so exact
+ * half-steps round away from zero symmetrically in both directions — plain
+ * `Math.round` on a negative shifted value rounds toward +Infinity (e.g.
+ * `Math.round(-23.5) === -23`), which would otherwise make `-2.35` round to
+ * `-2.3` while `2.35` rounds to `2.4`. Callers must only pass finite values.
+ */
+function roundToDecimals(value: number, decimals: number): number {
+  const sign = value < 0 ? -1 : 1;
+  const [coefficient, exponent] = Math.abs(value).toString().split('e');
+  const shifted = Number(`${coefficient}e${(exponent ? Number(exponent) : 0) + decimals}`);
+  const rounded = Math.round(shifted);
+  const [roundedCoefficient, roundedExponent] = rounded.toString().split('e');
+  const result = Number(
+    `${roundedCoefficient}e${(roundedExponent ? Number(roundedExponent) : 0) - decimals}`
+  );
+  return sign * result;
+}
+
+/**
+ * Rounds a single value to the decimal precision configured for `unit`.
+ * Unknown units (not present in {@link UNIT_DECIMALS}) and non-finite values
+ * (`NaN`, `Infinity`, `-Infinity` — e.g. via the `Number()` coercion
+ * `parseNumeric` uses upstream) are returned unchanged.
+ *
+ * @param value - Raw numeric measurement
+ * @param unit - Exact unit string as emitted in tool output (e.g. `'°C'`)
+ * @returns The value rounded to the unit's configured decimal places
+ */
+export function roundByUnit(value: number, unit: string): number {
+  if (!Number.isFinite(value)) return value;
+  const decimals = UNIT_DECIMALS[unit];
+  if (decimals === undefined) return value;
+  return roundToDecimals(value, decimals);
+}
+
+/** Rounds a nullable measurement value by unit; `null` passes through as `null`. */
+export function roundNullable(value: number | null, unit: string): number | null {
+  return value === null ? null : roundByUnit(value, unit);
+}
+
+/** Rounds an optional measurement value by unit; `undefined` passes through as `undefined`. */
+export function roundOptional(value: number | undefined, unit: string): number | undefined {
+  return value === undefined ? undefined : roundByUnit(value, unit);
+}

--- a/packages/meteoswiss-mcp/test/integration/ogd-climate-data.test.ts
+++ b/packages/meteoswiss-mcp/test/integration/ogd-climate-data.test.ts
@@ -101,6 +101,27 @@ describe('meteoswissClimateData Tool', () => {
     expect(result.content[0].text).toContain('station');
   });
 
+  it('rounds pressure_hpa and radiation_w_m2 at assembly time, leaving frost_days exact', async () => {
+    // Fixture row BAS 2024-01 has phsstam0=973.5 and ghs000m0=35.2, which must
+    // round to 974 and 35 respectively (both units have 0 decimal places).
+    // ths00nm0=12 (frost_days) is a day count, not a measurement, and must
+    // pass through byte-exact.
+    const result = await client.callTool('meteoswissClimateData', {
+      station: 'BAS',
+      resolution: 'monthly',
+      start_date: '2024-01-01',
+      end_date: '2024-01-31',
+      limit: 1,
+    });
+
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.data.length).toBe(1);
+    expect(data.data[0].pressure_hpa).toBe(974);
+    expect(data.data[0].radiation_w_m2).toBe(35);
+    expect(data.data[0].frost_days).toBe(12);
+  });
+
   // --- B2 regression tests (rc.2 failing cases) ---
 
   it('rejects gibberish station "INVALID_STATION_XYZ" with a helpful error', async () => {

--- a/packages/meteoswiss-mcp/test/integration/ogd-current-weather.test.ts
+++ b/packages/meteoswiss-mcp/test/integration/ogd-current-weather.test.ts
@@ -84,6 +84,18 @@ describe('meteoswissCurrentWeather Tool', () => {
     expect(result.content[0].text).toContain('station');
   });
 
+  it('rounds pressure_station to whole hPa at assembly time (fixture has 868.70)', async () => {
+    // Fixture row ABO has prestas0=868.70, which must round to 869 (hPa has
+    // 0 decimal places) rather than pass through as 868.7.
+    const result = await client.callTool('meteoswissCurrentWeather', {
+      station: 'ABO',
+    });
+
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.measurements.pressure_station.value).toBe(869);
+  });
+
   it('should include visual observations for OBS stations with all boolean fields', async () => {
     // ALT (Altdorf) is one of the 8 OBS stations with visual observations
     const result = await client.callTool('meteoswissCurrentWeather', {

--- a/packages/meteoswiss-mcp/test/integration/ogd-local-forecast.test.ts
+++ b/packages/meteoswiss-mcp/test/integration/ogd-local-forecast.test.ts
@@ -136,6 +136,27 @@ describe('meteoswissLocalForecast Tool', () => {
     expect(day.precipitation.hourly).toBeNull();
   });
 
+  it('rounds station-path temperature/precipitation to unit precision (1 decimal place)', async () => {
+    // Napf resolves to a station forecast (daily params, not hourly-aggregated).
+    // Fixture point 48, date 2026-03-26: tre200dn=-6.7, tre200dx=-3.7, rka150d0=11.3.
+    const result = await client.callTool('meteoswissLocalForecast', {
+      location: 'Napf',
+      days: 1,
+    });
+
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse(result.content[0].text);
+    const day = data.forecast[0];
+    expect(day.date).toBe('2026-03-26');
+    // Exact 1-decimal-place equality already proves the °C/mm rounding contract;
+    // a separate `value * 10` integer check would be flaky here since IEEE-754
+    // multiplication can turn an already-correct value like 12.3 into
+    // 123.00000000000001, making `Number.isInteger` fail on correct output.
+    expect(day.temperature.min).toBe(-6.7);
+    expect(day.temperature.max).toBe(-3.7);
+    expect(day.precipitation.total).toBe(11.3);
+  });
+
   it('should return error for empty location', async () => {
     const result = await client
       .callTool('meteoswissLocalForecast', { location: '' })

--- a/packages/meteoswiss-mcp/test/integration/ogd-pollen.test.ts
+++ b/packages/meteoswiss-mcp/test/integration/ogd-pollen.test.ts
@@ -121,6 +121,25 @@ describe('meteoswissPollenData Tool', () => {
     expect(birch!.value).toBe(1124); // d1 value, not d0=1326
   });
 
+  it('rounds pollen values to whole particles/m³ at assembly time', async () => {
+    // particles/m³ has 0 decimal places in UNIT_DECIMALS; every assembled
+    // *measured* value must respect that contract regardless of upstream CSV
+    // precision. 'no-current-data' entries carry no value/unit and are
+    // skipped here — they're a distinct, deliberately value-less variant.
+    const result = await client.callTool('meteoswissPollenData', { station: 'PZH' });
+    expect(result.isError).toBeFalsy();
+
+    const data = JSON.parse(result.content[0].text);
+    const station = data.stations[0];
+    const measured = station.pollen.filter(
+      (p: { status: string }) => p.status === 'measured'
+    );
+    expect(measured.length).toBeGreaterThan(0);
+    for (const p of measured) {
+      expect(Number.isInteger(p.value)).toBe(true);
+    }
+  });
+
   it('should return pollen data for a specific station', async () => {
     const result = await client.callTool('meteoswissPollenData', { station: 'PZH' });
     expect(result.isError).toBeFalsy();

--- a/packages/meteoswiss-mcp/test/unit/round-measurements.test.ts
+++ b/packages/meteoswiss-mcp/test/unit/round-measurements.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  roundByUnit,
+  roundNullable,
+  roundOptional,
+} from '../../src/support/round-measurements.js';
+
+describe('roundByUnit', () => {
+  it('rounds 1-decimal units', () => {
+    expect(roundByUnit(12.34, '°C')).toBe(12.3);
+  });
+
+  it('rounds 0-decimal units', () => {
+    expect(roundByUnit(1013.2, 'hPa')).toBe(1013);
+  });
+
+  it('rounds the remaining unit-table entries (guards against literal typos, e.g. unicode)', () => {
+    expect(roundByUnit(500.7, 'W/m²')).toBe(501);
+    expect(roundByUnit(183.6, '°')).toBe(184);
+    expect(roundByUnit(45.3, 'min')).toBe(45);
+    expect(roundByUnit(12.6, 'cm')).toBe(13);
+    expect(roundByUnit(1123.6, 'particles/m³')).toBe(1124);
+    expect(roundByUnit(3.456, 'm/s')).toBe(3.5);
+    expect(roundByUnit(7.89, 'mm')).toBe(7.9);
+    expect(roundByUnit(45.67, 'km/h')).toBe(45.7);
+  });
+
+  it('passes unknown units through unchanged', () => {
+    expect(roundByUnit(12.34567, 'furlongs')).toBe(12.34567);
+  });
+
+  it('rounds negative numbers correctly', () => {
+    expect(roundByUnit(-2.36, '°C')).toBe(-2.4);
+  });
+
+  it('leaves whole numbers as whole numbers', () => {
+    const result = roundByUnit(8, '°C');
+    expect(result).toBe(8);
+    expect(typeof result).toBe('number');
+  });
+
+  it('passes NaN through unchanged', () => {
+    expect(Number.isNaN(roundByUnit(NaN, '°C'))).toBe(true);
+  });
+
+  it('passes Infinity and -Infinity through unchanged', () => {
+    // parseNumeric uses Number(value), so non-finite input can reach this
+    // helper; string-shift rounding would otherwise corrupt it (e.g.
+    // `Number('Infinitye1')` is NaN), so it must be guarded explicitly.
+    expect(roundByUnit(Infinity, '°C')).toBe(Infinity);
+    expect(roundByUnit(-Infinity, 'mm')).toBe(-Infinity);
+  });
+
+  it('rounds the classic IEEE-754 half-step case correctly (0.15 -> 0.2, not 0.1)', () => {
+    // 0.15 * 10 === 1.4999999999999998 in IEEE-754, which naive
+    // Math.round(value * factor) / factor would floor to 0.1.
+    expect(roundByUnit(0.15, '°C')).toBe(0.2);
+    expect(roundByUnit(1.15, 'mm')).toBe(1.2);
+  });
+
+  it('rounds negative half-steps away from zero, symmetric with positive half-steps', () => {
+    // Math.round(-23.5) === -23 in JS (ties round toward +Infinity), which
+    // would otherwise make -2.35 round to -2.3 while 2.35 rounds to 2.4.
+    expect(roundByUnit(2.35, '°C')).toBe(2.4);
+    expect(roundByUnit(-2.35, '°C')).toBe(-2.4);
+  });
+});
+
+describe('roundNullable', () => {
+  it('rounds a number by unit', () => {
+    expect(roundNullable(12.3456, '°C')).toBe(12.3);
+  });
+
+  it('passes null through as null', () => {
+    expect(roundNullable(null, '°C')).toBeNull();
+  });
+});
+
+describe('roundOptional', () => {
+  it('rounds a number by unit', () => {
+    expect(roundOptional(12.3456, '°C')).toBe(12.3);
+  });
+
+  it('passes undefined through as undefined', () => {
+    expect(roundOptional(undefined, '°C')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

MCP tool output currently emits weather/climate/pollen measurements with raw CSV precision (e.g. temperature to 6+ decimal places). This PR adds unit-aware rounding.

Rounding is applied **at each tool's data-assembly point in `src/data/*.ts`**, not at the shared JSON serialization boundary. Every numeric value in a tool response is genuinely parsed from CSV (`parseNumeric(row[key])`) and explicitly placed into a typed response object by our own code — some via simple copies, some computed via `Math.min`/`Math.max`/`reduce` over hourly arrays — so there is no opaque pass-through of an upstream payload to round after the fact.

**Correct at construction, not corrected after the fact.** An earlier version of this PR applied rounding as a single recursive tree-walk (`roundMeasurementOutput`) wrapped around `JSON.stringify` at all 7 tool call sites in `src/server.ts` — mutating the already-assembled output at the serialization boundary. That's been reverted: `src/server.ts` now serializes with plain `JSON.stringify` again, and the tree-walk is gone. Instead, each value is rounded exactly once, at the point it's built, using the unit literal already in scope at that call site.

`src/support/round-measurements.ts` now exposes just the rounding primitives:
- `roundByUnit(value, unit)` — rounds a single number per a unit → decimals lookup table (`UNIT_DECIMALS`); unknown units and `NaN` pass through unchanged.
- `roundNullable(value, unit)` — same, for `number | null` (passes `null` through).
- `roundOptional(value, unit)` — same, for `number | undefined` (passes `undefined` through).

Each data-layer module calls these directly at its construction site:
- `ogd-current-weather.ts`: the shared `measurement()` helper rounds every `{ value, unit }` it builds (temperature, humidity, dew point, precipitation, wind speed/gust/direction, sunshine, radiation, pressure ×2, snow depth); `cloud_cover_percent` in `fetchVisualObservations()` is rounded separately.
- `ogd-local-forecast.ts`: station-path `temperature.min/max`/`precipitation.total`, hourly-aggregated-path `temperature.min/max` (from `Math.min`/`Math.max`) and `precipitation.total` (from `reduce`), and each `precipitation.hourly[]` entry.
- `ogd-climate-data.ts`: the 8 measurement fields in `mapMeasurement()` (temperature mean/max/min, precipitation, sunshine, radiation, wind speed, pressure).
- `ogd-pollen-data.ts`: the pollen `value` field.

## Per-unit rounding table

| Unit literal (as emitted in code, JS string) | Decimals |
|---|---|
| `'°C'` | 1 |
| `'km/h'` | 1 |
| `'m/s'` | 1 |
| `'mm'` | 1 |
| `'°'` (wind_direction bearing) | 0 |
| `'%'` | 0 |
| `'hPa'` | 0 |
| `'min'` | 0 |
| `'W/m²'` | 0 |
| `'cm'` | 0 |
| `'particles/m³'` | 0 |

Any unit not in this table is returned unchanged (no throw).

## Intentionally excluded (never rounded)

- `coordinates.lat` / `coordinates.lon` (WGS84 degrees)
- `station.elevation` / `location.elevation`
- `station.distance_km` (already pre-rounded 1dp upstream by `haversine.ts`, not unit-tagged)
- Climate day-count fields: `frost_days`, `summer_days`, `heat_days`, `ice_days`, `tropical_nights`, `rain_days`
- Counts/indices: `total` (stations), `totalResults`, `page`, `pageSize` (search)
- All strings: timestamps, dates, IDs, abbreviations, names

`meteoswissStations` output has no fields that go through rounding (only elevation/coords/total, all excluded), so its output is unaffected — confirmed by the existing integration tests still passing unchanged.

## Test plan

- [x] `test/unit/round-measurements.test.ts`: `roundByUnit` across all unit-table entries (1dp/0dp, negative numbers, whole numbers, unknown-unit passthrough, `NaN`), plus `roundNullable`/`roundOptional` null/undefined passthrough.
- [x] Assembly-level integration coverage added per data-layer module, pinned to fixture rows with genuine sub-target precision where available:
  - `ogd-current-weather.test.ts`: `pressure_station` 868.70 → 869 (hPa, 0dp) — a real rounding case, not a no-op.
  - `ogd-climate-data.test.ts`: `pressure_hpa` 973.5 → 974 and `radiation_w_m2` 35.2 → 35 (both real rounding), plus `frost_days` stays byte-exact at 12.
  - `ogd-local-forecast.test.ts` / `ogd-pollen.test.ts`: fixture data for these paths is already at (or below) target precision, so these are contract/smoke tests (exact expected values + a decimal-place-bound assertion), not proof of an active rounding step — the unit-level `roundByUnit` tests are the primary proof for those units.
- [x] `pnpm run fix && pnpm run ci` green (lint, build, unit + integration tests: 190 passed, 1 skipped).
- [x] No snapshot updates were needed.
- [x] Changeset (`meteoswiss-mcp`: minor) reviewed — user-facing behavior is unchanged from the previous version of this PR, only the implementation approach moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
