### PR TITLE
docs: reframe repo as agent-data-access showcase + skill-vs-MCP case study

### DIFF
--- a/.changeset/showcase-docs-rework.md
+++ b/.changeset/showcase-docs-rework.md
@@ -1,0 +1,5 @@
+---
+"meteoswiss-mcp": patch
+---
+
+Document the `meteoswissClimateData` tool on the service homepage, correct the station count in tool descriptions and docs (~300 measurement stations: ~160 full weather + ~140 precipitation-only), and link the new skill-vs-MCP case study from the homepage.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ What the tools provide:
 - **Climate series** from the National Basic Climatic Network (NBCN), going back decades
 - **MeteoSwiss website** search and content retrieval
 
-## What This Repo Demonstrates
+## What this repo demonstrates
 
 - **An agent skill** — teach an agent to fetch open data directly with `curl`/`awk`/`jq`: ~630 lines of markdown and bash, zero infrastructure. → [packages/meteoswiss-skills](packages/meteoswiss-skills/)
 - **An MCP server** — the same data as structured, validated tools with fuzzy station matching, geocoding, TTL-tiered caching, a real test suite, Docker, and a hosted instance. → [packages/meteoswiss-mcp](packages/meteoswiss-mcp/)
@@ -32,7 +32,7 @@ What the tools provide:
 
 Read the comparison: **[Skill vs. MCP Server: Two Ways to Give AI Agents the Same Data](docs/skill-vs-mcp.md)**.
 
-## Choose Your Approach
+## Choose your approach
 
 Both approaches answer the same weather questions. Which to install depends on your agent:
 
@@ -47,7 +47,7 @@ Both approaches answer the same weather questions. Which to install depends on y
 
 Full comparison — parity matrix, engineering trade-offs, context cost, when to choose which: [docs/skill-vs-mcp.md](docs/skill-vs-mcp.md).
 
-### MCP Server — Quickstart
+### MCP server — quickstart
 
 Use the hosted instance (no installation):
 
@@ -66,7 +66,7 @@ docker run -p 3000:3000 ghcr.io/eins78/meteoswiss-mcp:latest
 
 See the [meteoswiss-mcp README](packages/meteoswiss-mcp/README.md) for Claude Desktop setup, environment variables, and full documentation.
 
-### Agent Skill — Quickstart
+### Agent skill — quickstart
 
 Install via the Claude Code plugin marketplace:
 
@@ -83,7 +83,7 @@ pnpx skills add https://github.com/eins78/meteoswiss-llm-tools.git#packages/mete
 
 See the [meteoswiss-skills README](packages/meteoswiss-skills/README.md) for manual installation and details.
 
-## Available Tools (MCP Server)
+## Available tools (MCP server)
 
 | Tool | Description |
 |------|-------------|
@@ -95,7 +95,7 @@ See the [meteoswiss-skills README](packages/meteoswiss-skills/README.md) for man
 | `search` | Search MeteoSwiss website content (DE, FR, IT, EN) |
 | `fetch` | Fetch full content from MeteoSwiss pages |
 
-## Example Questions
+## Example questions
 
 Works with both approaches — just ask in any of Switzerland's four languages:
 
@@ -131,7 +131,7 @@ See each package's README for package-specific commands. The repo uses [changese
 
 Manual, point-in-time test reports (e.g. live MCP tool test passes) live in `docs/test-reports/`.
 
-## Data Source
+## Data source
 
 All weather data comes from [MeteoSwiss Open Government Data (OGD)](https://opendatadocs.meteoswiss.ch/) — the official free data offering from Switzerland's Federal Office of Meteorology and Climatology. The same data powers the MeteoSwiss app and website.
 

--- a/README.md
+++ b/README.md
@@ -7,27 +7,45 @@
 [![next](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fmeteoswiss-mcp-demo-test.cloud.kiste.li%2Fhealth&query=%24.version&label=next&color=lightgrey)](https://meteoswiss-mcp-demo-test.cloud.kiste.li/)
 [![Cursor Directory](https://img.shields.io/badge/Cursor_Directory-Add_to_Cursor-blue)](https://cursor.directory/plugins/meteoswiss-llm-tools)
 
-Swiss weather data for AI assistants — powered by [MeteoSwiss Open Data](https://opendatadocs.meteoswiss.ch/), the same data behind the MeteoSwiss app and website. Free, no API key required.
+Swiss weather data for AI assistants — powered by [MeteoSwiss Open Government Data (OGD)](https://opendatadocs.meteoswiss.ch/), the same data behind the MeteoSwiss app and website. Free, no API key required.
 
 **[meteoswiss-mcp.ars.is](https://meteoswiss-mcp.ars.is/)** — try the hosted service instantly, no setup needed.
 
+This repo is also a working answer to a design question: **how should you give AI agents access to a public dataset?** It implements the same MeteoSwiss data access twice — as an [agent skill](packages/meteoswiss-skills/) (markdown instructions plus bash scripts, no server) and as an [MCP server](packages/meteoswiss-mcp/) (structured tools, fuzzy matching, caching, hosted). The two approaches are compared honestly in the [skill vs. MCP case study](docs/skill-vs-mcp.md).
+
+A third piece, [meteoswiss-forecast-evals](packages/meteoswiss-forecast-evals/), demonstrates eval-driven interface design: a [promptfoo](https://promptfoo.dev/) suite measuring how well 13 LLMs read the forecast JSON, which settled a real design decision — local-time timestamps beat UTC, with hour-level lookups scoring ~100% vs. ~0%.
+
+What the tools provide:
+
 - **Multi-day forecasts** for ~6000 Swiss locations (postal codes, stations, place names)
-- **Real-time measurements** from ~160 automatic weather stations, updated every 10 minutes
+- **Real-time measurements** from ~300 stations (~160 full weather + ~140 precipitation-only), updated every 10 minutes
 - **Station discovery** by name, canton, or GPS coordinates
 - **Pollen monitoring** from ~15 stations across Switzerland
+- **Climate series** from the National Basic Climatic Network (NBCN), going back decades
 - **MeteoSwiss website** search and content retrieval
+
+## What This Repo Demonstrates
+
+- **An agent skill** — teach an agent to fetch open data directly with `curl`/`awk`/`jq`: ~630 lines of markdown and bash, zero infrastructure. → [packages/meteoswiss-skills](packages/meteoswiss-skills/)
+- **An MCP server** — the same data as structured, validated tools with fuzzy station matching, geocoding, TTL-tiered caching, a real test suite, Docker, and a hosted instance. → [packages/meteoswiss-mcp](packages/meteoswiss-mcp/)
+- **Eval-driven interface design** — treat tool output as an interface for a language model, and measure its legibility before shipping. → [packages/meteoswiss-forecast-evals](packages/meteoswiss-forecast-evals/)
+
+Read the comparison: **[Skill vs. MCP Server: Two Ways to Give AI Agents the Same Data](docs/skill-vs-mcp.md)**.
 
 ## Choose Your Approach
 
-This monorepo offers two ways to bring Swiss weather data into AI assistants:
+Both approaches answer the same weather questions. Which to install depends on your agent:
 
 | | [MCP Server](packages/meteoswiss-mcp/) | [Agent Skill](packages/meteoswiss-skills/) |
 |---|---|---|
-| **How it works** | Standalone server exposing structured tools via MCP | Teaches agents to call MeteoSwiss APIs directly via HTTP |
-| **Best for** | Claude Desktop, Claude.ai, any MCP client | Claude Code, Cursor, agents without MCP support |
-| **Features** | Fuzzy station matching, geocoding, structured JSON, prompts | Lightweight, no server process, shell scripts included |
-| **Install** | One-liner or Docker | Skill package or symlink |
-| **Requires** | Node.js 22+ (or Docker) | `curl`, `awk`, `jq` |
+| **What it is** | Standalone server exposing 7 structured tools via MCP | Markdown instructions + 5 bash scripts the agent runs directly |
+| **Works with** | Claude Desktop, Claude.ai, Cursor, any MCP client | Claude Code, Cursor, any agent with shell access |
+| **Coverage** | Forecasts, current weather, stations, pollen, climate series, website search | Forecasts, current weather, stations, pollen |
+| **Extras** | Fuzzy matching, geocoding, caching, DE/FR/IT prompts, structured JSON | No server, no Node.js — just `curl`, `awk`, `jq` |
+| **Size** | ~6.6k lines TypeScript, tested in CI | ~630 lines markdown + bash |
+| **Install** | One-liner (hosted), npm, or Docker | Plugin marketplace, Skills CLI, or symlink |
+
+Full comparison — parity matrix, engineering trade-offs, context cost, when to choose which: [docs/skill-vs-mcp.md](docs/skill-vs-mcp.md).
 
 ### MCP Server — Quickstart
 
@@ -73,6 +91,7 @@ See the [meteoswiss-skills README](packages/meteoswiss-skills/README.md) for man
 | `meteoswissCurrentWeather` | Real-time measurements (temperature, wind, humidity, pressure) |
 | `meteoswissStations` | Search station network by name, canton, or coordinates |
 | `meteoswissPollenData` | Pollen concentration data from monitoring stations |
+| `meteoswissClimateData` | NBCN climate series — temperature, precipitation, sunshine, and climate indicators going back decades |
 | `search` | Search MeteoSwiss website content (DE, FR, IT, EN) |
 | `fetch` | Fetch full content from MeteoSwiss pages |
 
@@ -91,6 +110,14 @@ Works with both approaches — just ask in any of Switzerland's four languages:
 |---------|---------|-------------|
 | [`meteoswiss-mcp`](packages/meteoswiss-mcp/) | [![npm](https://img.shields.io/npm/v/meteoswiss-mcp)](https://www.npmjs.com/package/meteoswiss-mcp) | MCP server with structured tools, fuzzy matching, and geocoding |
 | [`meteoswiss-skills`](packages/meteoswiss-skills/) | 1.0.0 | Agent skill — direct HTTP access, no server needed |
+| [`meteoswiss-forecast-evals`](packages/meteoswiss-forecast-evals/) | — | LLM eval suite for the forecast JSON format (standalone, not a workspace member) |
+
+## Documentation
+
+- [Skill vs. MCP case study](docs/skill-vs-mcp.md) — the honest comparison of the two approaches
+- [Eval results: forecast JSON comprehension](packages/meteoswiss-forecast-evals/docs/results/2026-07-09-forecast-json-comprehension.md) — the local-time-vs-UTC sweep
+- [MCP server user guide](packages/meteoswiss-mcp/docs/user-guide.md)
+- [Documentation index](docs/README.md)
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Documentation
+
+Public documentation for [meteoswiss-llm-tools](../README.md).
+
+## Start here
+
+- **[Skill vs. MCP Server](skill-vs-mcp.md)** — the case study at the heart of this repo: the same MeteoSwiss data access implemented as an agent skill and as an MCP server, compared honestly.
+- **[Eval results: forecast JSON comprehension](../packages/meteoswiss-forecast-evals/docs/results/2026-07-09-forecast-json-comprehension.md)** — how measuring LLM legibility of tool output settled a real design decision (local-time vs. UTC timestamps).
+- **[MCP server user guide](../packages/meteoswiss-mcp/docs/user-guide.md)** — using the hosted service and the tools.
+- **[MCP server package docs](../packages/meteoswiss-mcp/docs/)** — architecture, debugging, releasing.
+- **[Eval suite design](../packages/meteoswiss-forecast-evals/docs/spec.md)** — methodology behind the eval package.
+
+## Working notes
+
+The subdirectories here are internal working documents, kept in the repo for provenance rather than polished for reading:
+
+- [`plans/`](plans/) — design plans for past features
+- [`research/`](research/) — test reports and data surveys
+- [`sessionlogs/`](sessionlogs/) — development session logs

--- a/docs/sessionlogs/2026-07-11-showcase-docs-reframing.md
+++ b/docs/sessionlogs/2026-07-11-showcase-docs-reframing.md
@@ -63,3 +63,18 @@ Verified: `pnpm --filter meteoswiss-mcp run fix && run ci` green (21 suites, 175
 homepage served locally and checked for the new content; all relative links resolve (homepage
 links are absolute URLs, since that markdown is rendered by the server, not GitHub); every
 "MeteoSwiss app" mention says "app and website". All five PR CI checks green.
+
+## Follow-up: copy-editing pass
+
+A later pass ran the reworked showcase docs through a de-AI copy-edit (sentence-case headings,
+remove AI-writing tells), preserving every count, tool name, and URL:
+
+- Root README: section headings normalized to sentence case ("What this repo demonstrates",
+  "Choose your approach", "Available tools (MCP server)", "Example questions", "Data source",
+  and the two Quickstart subheadings).
+- `docs/skill-vs-mcp.md`: one phrasing fix — "serves as readable documentation" → "is also
+  readable documentation".
+- `meteoswiss-forecast-evals` README: dropped a "Note that" hedge.
+
+No facts changed: a number / tool-name / URL set comparison against the prior revision was
+identical for every edited file.

--- a/docs/sessionlogs/2026-07-11-showcase-docs-reframing.md
+++ b/docs/sessionlogs/2026-07-11-showcase-docs-reframing.md
@@ -1,0 +1,65 @@
+# Docs Reframing: Showcase + Skill-vs-MCP Case Study
+
+**Date:** 2026-07-11
+**Model:** Fable 5, worktree `quatico-showcase-docs`, branch `worktree-quatico-showcase-docs`
+**Related:** [PR #118](https://github.com/eins78/meteoswiss-llm-tools/pull/118)
+
+## Summary
+
+Reworked the public-facing docs so the repo reads as two things at once: a showcase of how to
+enable data access for AI agents (MeteoSwiss OGD as the worked example), and a case study
+comparing two implementations of the same problem — an agent skill (~630 lines markdown + bash)
+vs. an MCP server (~6.6k LOC TypeScript). Also fixed several accuracy bugs found along the way.
+
+## Key decisions
+
+**One anchor doc, stable URL.** All framing lives in the new `docs/skill-vs-mcp.md` (problem
+statement, both implementations, 12-row capability parity matrix, engineering comparison,
+context-cost reasoning, when to choose which, honest limitations). Everything else — root
+README, package READMEs, service homepage — carries only 1-2 framing sentences plus a link, so
+the READMEs stay scannable. A new `docs/README.md` indexes the public docs and labels `plans/`,
+`research/`, and `sessionlogs/` as internal working notes kept for provenance.
+
+**Three pillars in the root README.** Agent skill, MCP server, and the eval suite each get a
+bullet in a new "What This Repo Demonstrates" section. The evals earn pillar status as
+*eval-driven interface design*: tool output is an interface for a language model, and its
+legibility can be measured before shipping.
+
+**The comparison is architectural, not benchmarked — and the docs say so.** The eval suite
+measures how well 13 LLMs comprehend the forecast JSON *format* (local-time-with-offset vs. UTC
+timestamps); it is not a skill-vs-MCP harness. Rather than stretch it into a claim it doesn't
+support, the case study presents the skill-vs-MCP comparison as qualitative, adds an explicit
+"Limitations" section (no behavioral skill tests, no head-to-head benchmark, context costs
+reasoned not measured), and names a real head-to-head benchmark as future work.
+
+**Grounded claims only.** Line counts, tool lists, cache tiers, test volume, and eval numbers
+were verified against the code before writing. One plausible but unverifiable comparison row
+("time to first version") was cut.
+
+## Accuracy fixes
+
+- `meteoswissClimateData` was missing from every public tools table (root README, mcp README)
+  and from the service homepage `tools.md` entirely — added everywhere, with parameters taken
+  from `src/schemas/ogd-climate-data.ts`.
+- Station count "~160" was stale everywhere except the `meteoswissCurrentWeather` description —
+  the network has been ~300 (~160 full weather + ~140 precipitation-only) since the SMN-precip
+  merge (PR #62). Fixed in both `server.ts` tool descriptions (which the LLM reads for tool
+  selection), both READMEs, and the homepage views.
+- Root README "Packages" table omitted `meteoswiss-forecast-evals`; the evals `package.json`
+  description referenced PR #99 as if still pending.
+- `docs/architecture/api-design.md`'s current-tools list documented the removed
+  `meteoswissClimateNormals` and the old station count — surgically fixed; both architecture
+  docs still describe the scraping-era `meteoswissWeatherReport` tool and need a fuller refresh
+  (follow-up; the case study deliberately does not link them).
+
+## What shipped (PR #118)
+
+New: `docs/skill-vs-mcp.md`, `docs/README.md`, changeset (patch, `meteoswiss-mcp`).
+Reworked: root `README.md`, all three package READMEs, homepage `overview.md` + `tools.md`
+(live on next deploy), `server.ts` tool-description strings, root + evals `package.json`
+descriptions.
+
+Verified: `pnpm --filter meteoswiss-mcp run fix && run ci` green (21 suites, 175 tests);
+homepage served locally and checked for the new content; all relative links resolve (homepage
+links are absolute URLs, since that markdown is rendered by the server, not GitHub); every
+"MeteoSwiss app" mention says "app and website". All five PR CI checks green.

--- a/docs/skill-vs-mcp.md
+++ b/docs/skill-vs-mcp.md
@@ -1,0 +1,139 @@
+# Skill vs. MCP Server: Two Ways to Give AI Agents the Same Data
+
+This repo implements access to [MeteoSwiss Open Government Data (OGD)](https://opendatadocs.meteoswiss.ch/) **twice**: once as an [agent skill](../packages/meteoswiss-skills/) and once as an [MCP server](../packages/meteoswiss-mcp/). Same data source, same use cases, two architectures — which makes this a direct, apples-to-apples case study of the two main ways to give an AI agent access to a dataset.
+
+This document is the honest comparison. It is architectural and qualitative: capability parity, engineering effort, operational trade-offs, and context cost. It is **not** a benchmark — no head-to-head task evaluation between the two implementations exists yet (see [Limitations](#limitations)).
+
+## The problem
+
+MeteoSwiss publishes its weather data as Open Government Data: CSV files and a STAC API on `data.geo.admin.ch`, free, no API key. An AI agent that should answer "Will it rain in Bern tomorrow?" needs to:
+
+1. Find the right dataset (current measurements, forecasts, pollen, climate series are separate collections).
+2. Resolve the user's location to a station abbreviation or forecast point ID (~6000 points, ~300 stations).
+3. Handle format quirks: semicolon-delimited CSVs, Latin1-encoded metadata files, `YYYYMMDDHHmm` UTC timestamps, a known typo in a STAC asset key.
+4. Return the answer in a form the model reliably interprets.
+
+There are two established ways to package that knowledge for an agent:
+
+- **A skill** — instructions and helper scripts the agent loads on demand and executes itself, using tools it already has (shell, HTTP).
+- **An MCP server** — a running service that exposes the operations as typed, validated tools via the [Model Context Protocol](https://modelcontextprotocol.io/).
+
+This repo builds both, at production quality, so the trade-offs are visible in real code instead of argued in the abstract.
+
+## The two implementations
+
+### The skill: ~630 lines of markdown and bash
+
+[`packages/meteoswiss-skills`](../packages/meteoswiss-skills/) ships one skill, [`meteoswiss-ogd`](../packages/meteoswiss-skills/skills/meteoswiss-ogd/SKILL.md):
+
+| File | Lines | Role |
+|---|---|---|
+| `SKILL.md` | 123 | Trigger description + curl/awk/jq recipes for each data type |
+| `REFERENCE.md` | 205 | Parameter codes, weather-icon codes, pollen codes, STAC collections |
+| `scripts/*.sh` (5 files) | 264 | Token-efficient wrappers: fetch, decode, filter, print `key=value` pairs |
+
+The agent does the work itself: it reads the recipes, composes `curl | iconv | awk` pipelines (or calls the bundled scripts), and interprets raw CSV rows. Domain knowledge that the MCP server encodes in TypeScript — the Latin1 encoding of metadata files, the two-step STAC item lookup, the hourly-to-daily aggregation for postal-code forecasts — lives here as prose and shell.
+
+The design follows progressive disclosure: `SKILL.md` stays small (it enters the context only when triggered), heavy lookup tables live in `REFERENCE.md`, which the agent reads only when needed.
+
+Requirements: an agent with shell access, plus `curl`, `awk`, `iconv` (and `jq` for forecasts). No server, no Node.js, no deployment.
+
+### The MCP server: ~6.6k lines of TypeScript
+
+[`packages/meteoswiss-mcp`](../packages/meteoswiss-mcp/) is a Streamable-HTTP MCP server (49 source files) exposing seven tools — `meteoswissLocalForecast`, `meteoswissCurrentWeather`, `meteoswissStations`, `meteoswissPollenData`, `meteoswissClimateData`, `search`, `fetch` — plus four preconfigured prompts (DE/FR/IT).
+
+The same domain knowledge is encoded as infrastructure:
+
+- **Location resolution** — fuzzy station-name matching with diacritic normalization, geocoding and reverse geocoding via geo.admin.ch, nearest-station lookup by coordinates. "Bahnhofplatz 1 Bern" works.
+- **Caching** — TTL-tiered disk cache (60 s realtime, 1 h forecast, 24 h metadata, 7 d climate), so a hosted instance doesn't hammer the upstream on every question.
+- **Validated I/O** — Zod schemas on every tool input; responses are compact structured JSON, not raw CSV.
+- **Operations** — session management, health endpoint, Docker image, and a hosted instance at [meteoswiss-mcp.ars.is](https://meteoswiss-mcp.ars.is/) that any MCP client can use with zero installation.
+- **Tests** — ~3.1k lines of unit and integration tests, run in CI against recorded fixtures.
+
+Requirements: Node.js 22+ or Docker to self-host — or nothing at all, using the hosted instance.
+
+## Capability parity
+
+| Capability | Skill | MCP server |
+|---|---|---|
+| Multi-day local forecast | ✅ recipe + `forecast.sh` | ✅ `meteoswissLocalForecast` |
+| Current weather (10-min updates) | ✅ recipe + `current-weather.sh` | ✅ `meteoswissCurrentWeather` |
+| Weather-station search | ✅ recipe + `search-stations.sh` | ✅ `meteoswissStations` |
+| Forecast-point search (~6000 points) | ✅ recipe + `search-forecast-points.sh` | ✅ built into forecast location resolution |
+| Pollen data | ✅ recipe + `pollen.sh` | ✅ `meteoswissPollenData` |
+| Climate series (NBCN, decades back) | ❌ | ✅ `meteoswissClimateData` |
+| MeteoSwiss website search + page fetch | ❌ | ✅ `search`, `fetch` |
+| Fuzzy station-name matching | ❌ (exact/substring grep; agent improvises) | ✅ |
+| Geocoding (address → nearest station) | ❌ | ✅ |
+| Structured JSON output | ❌ (raw CSV / `key=value`) | ✅ |
+| Preconfigured multilingual prompts | ❌ | ✅ 4 (DE/FR/IT) |
+| Response caching | ❌ (agent fetches fresh each time) | ✅ TTL-tiered |
+
+The skill covers the five core data-access capabilities. Everything below the line is where the server's extra ~6000 lines went: convenience, robustness, and coverage that instructions alone don't provide.
+
+## Engineering comparison
+
+| | Skill | MCP server |
+|---|---|---|
+| Code size | ~630 lines (markdown + bash) | ~6.6k lines TypeScript, 49 files |
+| Runtime requirements | `curl`, `awk`, `iconv`, `jq` in the agent's shell | Node.js 22+ / Docker — or none (hosted) |
+| Works with | Agents with shell access (Claude Code, Cursor, …) | Any MCP client, including ones without shell access (Claude Desktop, Claude.ai) |
+| Testing | Structural validation only (`skills` CLI in CI) | ~3.1k lines of unit + integration tests in CI |
+| Distribution | Copy files: plugin marketplace, Skills CLI, or symlink | npm package, Docker image, hosted endpoint |
+| Update path | Users reinstall the skill files | Redeploy; hosted users get updates transparently |
+| Failure handling | Agent improvises from raw error output | Server-side validation, typed error messages |
+| Where compute happens | In the agent's sandbox, per request | On the server, cached across users |
+
+## Context cost
+
+A qualitative comparison — these numbers are **not measured**, but the mechanics differ in ways worth understanding:
+
+- **MCP**: the seven tool schemas are sent to the model in every session, whether or not weather comes up. In exchange, each actual query is cheap: one tool call, one compact JSON response.
+- **Skill**: only a one-line trigger description is always present. When triggered, the agent loads `SKILL.md` (~120 lines), possibly `REFERENCE.md` (~200 lines), and then spends turns composing and running shell commands, with raw CSV output entering the context. Idle cost is near zero; active cost is higher and more variable.
+
+So the skill is cheaper when weather questions are rare, the server is cheaper when they're frequent — and the server's structured output reduces the risk of the model misreading raw data. Measuring this properly would be a natural extension of the eval suite below.
+
+## What the evals showed
+
+[`packages/meteoswiss-forecast-evals`](../packages/meteoswiss-forecast-evals/) is the third piece of the showcase: a [promptfoo](https://promptfoo.dev/) suite that treats **tool output as an interface for a language model** and measures its legibility before shipping.
+
+To be clear about what it is not: **it does not compare the skill against the MCP server.** It compares two candidate JSON formats for the `meteoswissLocalForecast` hourly-precipitation time-series — timestamps in **local time with UTC offset** (`2026-03-28T09:00:00+01:00`) vs. **UTC** (`2026-03-28T08:00:00Z`) — across 13 models in three price tiers, with 33 programmatically generated lookup questions and a small LLM-judged slice. Ground truth is computed from the fixture, never hand-typed.
+
+The result was decisive: on exact-value lookups at a specific local hour, models scored **~100% with local-time labels vs. ~0% with UTC** — across every tier, including frontier models. That settled a real design decision (the feature shipped with local-time labels) and is documented in the [2026-07-09 results](../packages/meteoswiss-forecast-evals/docs/results/2026-07-09-forecast-json-comprehension.md).
+
+The lesson generalizes to both approaches in this case study: whatever the transport — MCP tool response or CSV parsed by a skill — the format the model reads is an interface, and its legibility can and should be measured, not assumed.
+
+## When to choose which
+
+**Choose a skill when:**
+
+- Your agents have shell access (coding agents, CLI agents).
+- The data source is public, stable, and simple enough to describe in a few pages.
+- You want zero infrastructure — nothing to deploy, monitor, or pay for.
+- Occasional, exploratory use; the agent's flexibility matters more than consistency.
+
+**Choose an MCP server when:**
+
+- You need to reach clients without shell access (chat apps, desktop assistants).
+- Location resolution, caching, or upstream-API etiquette require real logic.
+- You want typed inputs, structured outputs, and a testable surface in CI.
+- Many users share the same access — a hosted server amortizes the work and caching.
+
+**Or do both**, as this repo does: the implementations share no code but encode the same domain knowledge, and the skill explicitly points agents to the MCP server for the cases it doesn't cover. The skill also serves as readable documentation of what the server automates.
+
+## Limitations
+
+Stated plainly, so the comparison stays honest:
+
+- **No behavioral tests for the skill.** CI validates its structure (`skills` CLI), not whether the recipes still work against the live OGD endpoints. The MCP server has integration tests; the skill has none.
+- **No head-to-head benchmark.** Nothing here measures "same question, both implementations, which answers better/cheaper/faster." The eval suite is the natural foundation for that — it is future work.
+- **Context costs are reasoned, not measured** (see [Context cost](#context-cost)).
+- **Coverage is asymmetric.** The skill covers 5 of the server's 7 tool areas; climate series and website search/fetch are server-only.
+- **One dataset, one domain.** MeteoSwiss OGD is friendly: free, no auth, no rate-limit drama. Datasets requiring auth, pagination, or write operations would shift the trade-offs toward the server.
+
+## Related reading
+
+- [Eval results: forecast JSON comprehension (2026-07-09)](../packages/meteoswiss-forecast-evals/docs/results/2026-07-09-forecast-json-comprehension.md) — the full local-time-vs-UTC sweep
+- [Eval suite design](../packages/meteoswiss-forecast-evals/docs/spec.md) — methodology, fixtures, scorer
+- [The skill itself](../packages/meteoswiss-skills/skills/meteoswiss-ogd/SKILL.md) — short enough to read in one sitting
+- [MCP server package](../packages/meteoswiss-mcp/) — tools, self-hosting, development

--- a/docs/skill-vs-mcp.md
+++ b/docs/skill-vs-mcp.md
@@ -119,7 +119,7 @@ The lesson generalizes to both approaches in this case study: whatever the trans
 - You want typed inputs, structured outputs, and a testable surface in CI.
 - Many users share the same access — a hosted server amortizes the work and caching.
 
-**Or do both**, as this repo does: the implementations share no code but encode the same domain knowledge, and the skill explicitly points agents to the MCP server for the cases it doesn't cover. The skill also serves as readable documentation of what the server automates.
+**Or do both**, as this repo does: the implementations share no code but encode the same domain knowledge, and the skill explicitly points agents to the MCP server for the cases it doesn't cover. The skill is also readable documentation of what the server automates.
 
 ## Limitations
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "meteoswiss-llm-tools",
-  "description": "Swiss weather data for AI assistants — powered by MeteoSwiss Open Data",
+  "description": "Swiss weather data for AI agents \u2014 MeteoSwiss open data exposed two ways: MCP server and agent skill",
   "license": "CC0-1.0",
   "scripts": {
     "changeset": "changeset",

--- a/packages/meteoswiss-forecast-evals/README.md
+++ b/packages/meteoswiss-forecast-evals/README.md
@@ -9,7 +9,7 @@ captured from it (see `fixtures/`).
 
 In the repo's showcase framing, this package demonstrates **eval-driven interface design**: the
 JSON an MCP tool returns is an interface for a language model, and its legibility can be measured
-before shipping instead of assumed. Note that this suite compares JSON *formats* across models —
+before shipping instead of assumed. This suite compares JSON *formats* across models —
 it does **not** compare the agent skill against the MCP server; see
 [docs/skill-vs-mcp.md](../../docs/skill-vs-mcp.md) for that (qualitative) comparison.
 

--- a/packages/meteoswiss-forecast-evals/README.md
+++ b/packages/meteoswiss-forecast-evals/README.md
@@ -7,6 +7,12 @@ Eval suite measuring how well LLMs **understand** the JSON returned by `meteoswi
 package: it does **not** depend on `meteoswiss-mcp`'s source, only on a static JSON sample
 captured from it (see `fixtures/`).
 
+In the repo's showcase framing, this package demonstrates **eval-driven interface design**: the
+JSON an MCP tool returns is an interface for a language model, and its legibility can be measured
+before shipping instead of assumed. Note that this suite compares JSON *formats* across models —
+it does **not** compare the agent skill against the MCP server; see
+[docs/skill-vs-mcp.md](../../docs/skill-vs-mcp.md) for that (qualitative) comparison.
+
 **Not run in CI.** This is a manual, on-demand suite — run it when you're about to change the
 forecast JSON shape, or periodically to catch regressions in legibility as models change.
 

--- a/packages/meteoswiss-forecast-evals/package.json
+++ b/packages/meteoswiss-forecast-evals/package.json
@@ -2,7 +2,7 @@
   "name": "meteoswiss-forecast-evals",
   "version": "0.1.0",
   "private": true,
-  "description": "Eval suite measuring how well LLMs understand meteoswissLocalForecast JSON, especially the hourly precipitation time-series (PR #99)",
+  "description": "Eval suite measuring how well LLMs read meteoswissLocalForecast JSON \u2014 eval-driven interface design for tool outputs",
   "author": "Max Albrecht <1@178.is>",
   "license": "CC0-1.0",
   "type": "module",

--- a/packages/meteoswiss-mcp/README.md
+++ b/packages/meteoswiss-mcp/README.md
@@ -7,12 +7,15 @@
 
 MCP server for MeteoSwiss weather data — powered by [MeteoSwiss Open Data](https://opendatadocs.meteoswiss.ch/), the same data behind the MeteoSwiss app and website.
 
+This package is the *server* half of the repo's [skill vs. MCP case study](../../docs/skill-vs-mcp.md) — the same data is also available as a no-infrastructure [agent skill](../meteoswiss-skills/).
+
 **[meteoswiss-mcp.ars.is](https://meteoswiss-mcp.ars.is/)** — try it now, no setup needed.
 
 - **Multi-day forecasts** for ~6000 Swiss locations (postal codes, stations, place names)
-- **Real-time measurements** from ~160 automatic weather stations, updated every 10 minutes
+- **Real-time measurements** from ~300 stations (~160 full weather + ~140 precipitation-only), updated every 10 minutes
 - **Station discovery** by name, canton, or GPS coordinates
 - **Pollen monitoring** from ~15 stations across Switzerland
+- **Climate series** from the National Basic Climatic Network (NBCN), going back decades
 - **MeteoSwiss website** search and content retrieval
 
 ## Use the Hosted Service
@@ -65,6 +68,7 @@ Go to **Settings** → **Integrations** → **Add MCP Server** → paste `https:
 | `meteoswissCurrentWeather` | Real-time measurements from automatic weather stations (temperature, wind, humidity, pressure) |
 | `meteoswissStations` | Search and browse the MeteoSwiss station network by name, canton, or coordinates |
 | `meteoswissPollenData` | Current pollen concentration data from monitoring stations |
+| `meteoswissClimateData` | NBCN climate series — temperature, precipitation, sunshine, and climate indicators going back decades |
 | `search` | Search MeteoSwiss website content (DE, FR, IT, EN) |
 | `fetch` | Fetch full content from MeteoSwiss pages in markdown, text, or HTML |
 

--- a/packages/meteoswiss-mcp/docs/architecture/api-design.md
+++ b/packages/meteoswiss-mcp/docs/architecture/api-design.md
@@ -162,9 +162,9 @@ The server fully implements the Model Context Protocol specification:
 Beyond `meteoswissWeatherReport`, the server provides these OGD-based tools:
 
 - **meteoswissLocalForecast** — Multi-day weather forecast for ~6000 Swiss locations (postal codes, stations, mountain POIs)
-- **meteoswissCurrentWeather** — Real-time measurements from ~160 automatic weather stations
+- **meteoswissCurrentWeather** — Real-time measurements from ~300 measurement stations (~160 full weather + ~140 precipitation-only)
 - **meteoswissStations** — List and search MeteoSwiss automatic weather stations
-- **meteoswissClimateNormals** — 1991-2020 climate normal values (30-year averages)
+- **meteoswissClimateData** — Homogeneous NBCN climate series (daily/monthly/yearly, decades back)
 - **meteoswissPollenData** — Current pollen concentration data from ~15 monitoring stations
 - **search** — Search MeteoSwiss website content (DE, FR, IT, EN)
 - **fetch** — Fetch full content from MeteoSwiss webpages

--- a/packages/meteoswiss-mcp/parity/tool-inventory.json
+++ b/packages/meteoswiss-mcp/parity/tool-inventory.json
@@ -1099,7 +1099,7 @@
     },
     {
       "name": "meteoswissStations",
-      "description": "List and search MeteoSwiss automatic weather stations. Filter by name, canton, or browse the full network of ~160 stations across Switzerland.",
+      "description": "List and search MeteoSwiss measurement stations. Filter by name, canton, or browse the full network of ~300 stations (~160 full weather + ~140 precipitation-only) across Switzerland.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/packages/meteoswiss-mcp/src/server.ts
+++ b/packages/meteoswiss-mcp/src/server.ts
@@ -295,7 +295,7 @@ Accepts station names ("Zurich"), abbreviations ("SMA"), addresses ("Bahnhofplat
   server.registerTool(
     'meteoswissStations',
     {
-      description: `List and search MeteoSwiss automatic weather stations. Filter by name, canton, or browse the full network of ~160 stations across Switzerland.`,
+      description: `List and search MeteoSwiss measurement stations. Filter by name, canton, or browse the full network of ~300 stations (~160 full weather + ~140 precipitation-only) across Switzerland.`,
       inputSchema: ListStationsParamsSchema.shape,
       outputSchema: StationListResponseSchema.shape,
     },

--- a/packages/meteoswiss-mcp/src/views/homepage/overview.md
+++ b/packages/meteoswiss-mcp/src/views/homepage/overview.md
@@ -10,14 +10,18 @@ Swiss weather data for AI assistants — powered by [MeteoSwiss Open Data](https
 ## What You Get
 
 - **Multi-day forecasts** for ~6000 Swiss locations — postal codes, station names, or place names
-- **Real-time measurements** from ~160 automatic weather stations, updated every 10 minutes
+- **Real-time measurements** from ~300 stations (~160 full weather + ~140 precipitation-only), updated every 10 minutes
 - **Station search** by name, canton, or GPS coordinates
 - **Pollen monitoring** from ~15 stations across Switzerland
+- **Climate series** from the National Basic Climatic Network (NBCN), going back decades
 
 All data comes from the official MeteoSwiss Open Data platform — the same data behind the MeteoSwiss app and website.
+
+This server is part of [meteoswiss-llm-tools](https://github.com/eins78/meteoswiss-llm-tools), an open-source showcase that implements the same data access both as an MCP server and as an agent skill — see the [skill vs. MCP case study](https://github.com/eins78/meteoswiss-llm-tools/blob/main/docs/skill-vs-mcp.md).
 
 ## Quick Links
 
 - [Get Started](#get-started)
 - [Available Tools](#available-tools)
 - [GitHub Repository](https://github.com/eins78/meteoswiss-llm-tools)
+- [Skill vs. MCP Case Study](https://github.com/eins78/meteoswiss-llm-tools/blob/main/docs/skill-vs-mcp.md)

--- a/packages/meteoswiss-mcp/src/views/homepage/tools.md
+++ b/packages/meteoswiss-mcp/src/views/homepage/tools.md
@@ -56,7 +56,7 @@ Get homogeneous climate series from Switzerland's National Basic Climatic Networ
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `station` | string | No | Station name ("Zurich"), abbreviation ("BAS"), or NBCN station |
+| `station` | string | No | Climate station name ("Zurich") or abbreviation ("BAS") |
 | `coordinates` | object | No | `{ lat, lon }` in WGS84 — finds nearest climate station |
 | `resolution` | string | No | `daily`, `monthly` (default), or `yearly` |
 | `start_date` | string | No | Start date filter (`YYYY-MM-DD`) |

--- a/packages/meteoswiss-mcp/src/views/homepage/tools.md
+++ b/packages/meteoswiss-mcp/src/views/homepage/tools.md
@@ -15,7 +15,7 @@ Get a multi-day weather forecast for any Swiss location.
 
 ## meteoswissCurrentWeather
 
-Get real-time measurements from any of ~160 Swiss automatic weather stations. Updated every 10 minutes.
+Get real-time measurements from any of ~300 Swiss measurement stations (~160 full weather + ~140 precipitation-only). Updated every 10 minutes.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -49,6 +49,23 @@ Get current pollen concentration data from ~15 MeteoSwiss monitoring stations.
 | `station` | string | No | Filter by station name or abbreviation |
 
 **Returns:** Pollen types and concentration levels per station.
+
+## meteoswissClimateData
+
+Get homogeneous climate series from Switzerland's National Basic Climatic Network (NBCN) — 29 climate stations + 46 precipitation stations, with data going back decades.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `station` | string | No | Station name ("Zurich"), abbreviation ("BAS"), or NBCN station |
+| `coordinates` | object | No | `{ lat, lon }` in WGS84 — finds nearest climate station |
+| `resolution` | string | No | `daily`, `monthly` (default), or `yearly` |
+| `start_date` | string | No | Start date filter (`YYYY-MM-DD`) |
+| `end_date` | string | No | End date filter (`YYYY-MM-DD`) |
+| `limit` | number | No | Maximum data rows, 1-365 (default: 30) |
+
+**Returns:** Temperature, precipitation, sunshine, radiation, wind, pressure, and climate indicators (frost days, summer days, heat days).
+
+**Try:** "What are typical January temperatures in Zurich?" or "How has precipitation changed in Basel over 50 years?"
 
 ## search
 

--- a/packages/meteoswiss-skills/README.md
+++ b/packages/meteoswiss-skills/README.md
@@ -2,7 +2,7 @@
 
 Agent skill that teaches AI agents to access [MeteoSwiss Open Government Data](https://opendatadocs.meteoswiss.ch/) directly via HTTP — no MCP server or API key required.
 
-Part of the [meteoswiss-llm-tools](../../README.md) monorepo. For a richer experience with structured JSON and fuzzy matching, see the [MCP server](../meteoswiss-mcp/) or try it at **[meteoswiss-mcp.ars.is](https://meteoswiss-mcp.ars.is/)**.
+Part of the [meteoswiss-llm-tools](../../README.md) monorepo. This package is the *skill* half of the repo's [skill vs. MCP case study](../../docs/skill-vs-mcp.md): the same data access as [`meteoswiss-mcp`](../meteoswiss-mcp/), implemented in ~630 lines of markdown and bash instead of a server. For structured JSON and fuzzy matching, use the MCP server — or try it hosted at **[meteoswiss-mcp.ars.is](https://meteoswiss-mcp.ars.is/)**.
 
 ## Skills
 
@@ -34,6 +34,8 @@ ln -s /path/to/packages/meteoswiss-skills/skills/meteoswiss-ogd ~/.claude/skills
 ## Relationship to MCP Server
 
 The [`meteoswiss-mcp`](../meteoswiss-mcp/) package in this monorepo provides a full MCP server with structured JSON responses, fuzzy station matching, and geocoding. This skill is for agents that don't have the MCP server available — it teaches them to call the same underlying data sources directly.
+
+The skill covers forecasts, current weather, station search, and pollen. Climate series (NBCN) and MeteoSwiss website search/fetch are MCP-only — see the [capability parity matrix](../../docs/skill-vs-mcp.md#capability-parity) for the full comparison.
 
 ## Development
 


### PR DESCRIPTION
## What this does

Reframes the public-facing docs so the repo reads as two things at once:

1. **A showcase** of how to enable data access for AI agents, using MeteoSwiss OGD as the worked example.
2. **A case study** comparing two implementations of the same problem: an agent **skill** (~630 lines markdown + bash) vs an **MCP server** (~6.6k LOC TypeScript).

**Deliberately vendor-neutral** — no company branding or marketing anywhere; written as a high-quality open-source showcase that stands on its own.

## Changes

- **New anchor doc: `docs/skill-vs-mcp.md`** — problem statement, both implementations, capability parity matrix, engineering comparison, context-cost reasoning, what the evals showed, when to choose which, and honest limitations. Everything else links here.
- **New `docs/README.md`** — public docs index; labels `plans/`/`research/`/`sessionlogs/` as internal working notes.
- **Root README** — leads with the dual framing and three pillars (skill, MCP server, eval-driven interface design); upgraded comparison table; adds the evals package to the Packages table; new Documentation section.
- **Package READMEs** — each states its role in the case study in 1-2 sentences and cross-links the comparison. The evals README explicitly notes it compares JSON *formats*, not skill-vs-server.
- **Service homepage** (`src/views/homepage/`, live on next deploy) — one showcase sentence + case-study link, new `meteoswissClimateData` tool section, corrected station counts.
- **Accuracy fixes** — `meteoswissClimateData` was missing from every tools table and the homepage; station count "~160" was stale everywhere except the currentWeather description (network is ~300 since precipitation-only stations were merged; fixed incl. the `meteoswissStations` tool description in `server.ts`).
- **Metadata** — root + evals `package.json` descriptions; changeset (patch, `meteoswiss-mcp`).

## Accuracy note on the evals

The eval suite measures how well 13 LLMs comprehend the forecast JSON format (local-time vs UTC) — it is **not** a skill-vs-MCP benchmark, and the docs now say so explicitly. The skill-vs-MCP comparison is presented as architectural/qualitative; a head-to-head benchmark is named as future work in the case study's Limitations section.

## Verification

- `pnpm --filter meteoswiss-mcp run fix` + `run ci` — green (21 suites, 175 tests passed, 1 skipped).
- Homepage rendered locally and checked: climate tool section, corrected counts, and case-study link all present in served HTML.
- All relative markdown links verified to resolve; homepage links are absolute GitHub URLs.
- Greps: no vendor references; no stale "~160" outside dated internal research/sessionlog records; every "MeteoSwiss app" mention says "app and website".

## Follow-ups (out of scope, noted while working)

- `packages/meteoswiss-mcp/docs/architecture/{api-design,overview}.md` still document the removed `meteoswissWeatherReport` tool (scraping era). The current-tools list in api-design.md got a surgical fix, but both docs deserve a refresh; the case study deliberately does not link them.
- Some `node_modules/.bin` shims are accidentally git-tracked (since the skills-rename commit) — should be untracked in a separate cleanup.
- GitHub repo description/topics could be updated to match the new framing (`gh repo edit`) — left for Max.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

