### PR TITLE
docs: add sessionlog for issue #110 QA sweep (PR #116)

### DIFF
--- a/docs/sessionlogs/2026-07-11-issue-110-qa-sweep-fixes.md
+++ b/docs/sessionlogs/2026-07-11-issue-110-qa-sweep-fixes.md
@@ -1,0 +1,71 @@
+# Issue #110 QA Sweep — 9 Fixes, Copilot Review Loop, Merge
+
+**Date:** 2026-07-11
+**Source:** Claude Code
+**Session:** Reconstructed from 1 compaction · ~146k input / ~376k output tokens
+**Branch:** `bug/issue-110-qa-sweep-v2.3.2` (merged, deleted)
+**PR:** https://github.com/eins78/meteoswiss-llm-tools/pull/116 (merged as `fddfa63`, closes #110)
+
+## Summary
+
+Implemented all 9 findings from a 3-model black-box QA sweep of meteoswiss-mcp v2.3.2 (issue #110), opened PR #116, ran it through 3 rounds of Copilot automated review, squash-cleaned the history, and merged with a real merge commit per Max's explicit policy.
+
+## Key Accomplishments
+
+- Fixed `search` pageSize (upstream Solr ignores `rows`, always returns 10; fixed the `start` offset math and stopped advertising an unhonored param)
+- Dropped the duplicate `content` field from `fetch` responses, keeping canonical `text` (breaking change, approved)
+- `meteoswissCurrentWeather` coordinate lookups now skip sparse stations lacking temperature in favor of the nearest capable one (DECISION-4)
+- `meteoswissCurrentWeather("Zurich")` now resolves to SMA (Fluntern) instead of KLO (Kloten), matching `meteoswissClimateData` (DECISION-5)
+- `meteoswissPollenData` always reports all 7 OGD-measured species with an explicit `no-current-data` marker; Ambrosia documented as forecast-only, not measured (DECISION-3)
+- Mapped previously-unmapped forecast weather icon codes 36–42
+- Fixed the invalid `"ZUE"` example (→ `"SMA"`) across schema/tool descriptions and docs
+- Added a `note` with the available date range when a daily climate query's filter returns no rows
+- Stripped `mch-icon` web components so decorative SVG titles (e.g. "chevron-small-right") stop leaking into `fetch` markdown/text output
+- Added a changeset (`meteoswiss-mcp`: minor) covering all 9 fixes and both breaking changes
+- Ran 3 rounds against Copilot's automated PR review, fixing every correctness/perf finding it raised
+- Cleaned commit history via soft reset + single re-commit (tree content identical to the last Copilot-approved state) before merging
+
+## Changes Made
+
+- Modified (via PR #116, squashed to one commit `833345e`, merged as `fddfa63`):
+  - `src/data/meteoswiss-search-data.ts`, `src/schemas/meteoswiss-search.ts`
+  - `src/data/meteoswiss-content-data.ts`
+  - `src/data/ogd-current-weather.ts`, `src/data/ogd-smn-stations.ts`, `src/data/ogd-station-resolver.ts`
+  - `src/data/ogd-pollen-data.ts`, `src/schemas/ogd-pollen-data.ts`
+  - `src/support/weather-icons.ts`
+  - `src/schemas/ogd-local-forecast.ts`, `src/views/homepage/tools.md`
+  - `src/data/ogd-climate-data.ts`, `src/schemas/ogd-climate-data.ts`
+  - `src/data/meteoswiss-web-components.ts`
+  - `src/server.ts`
+  - `docs/validation-errors.md`
+  - Test fixtures: `VQHA80.csv`, `ogd-smn_meta_stations.csv`, `pzh-daily-recent.csv`
+  - Integration/unit tests across search, fetch, pollen, current-weather, climate-data, weather-icons
+- Created: `.changeset/qa-sweep-issue-110-fixes.md`
+
+## Decisions
+
+- **Fetch field dedup (issue comment "DECISION-2" contradicted live code):** the recorded decision said "keep `content`, drop `text`" — but `text` is the canonical field required by the ChatGPT Deep Research MCP `fetch` contract, and `content` was already marked `@deprecated, removed in 3.0`. Verified this live before implementing, escalated to Max via a direct question rather than guessing. **Resolved: drop `content`, keep `text`.**
+- **Ambrosia pollen handling (issue comment "DECISION-3" built on a wrong premise):** the recorded decision assumed Ambrosia was a measured-but-out-of-season OGD species. Live verification of all 3 OGD pollen metadata files showed Ambrosia isn't in the OGD measurement network at all — only in a separate MeteoSwiss forecast product. Escalated to Max. **Resolved: omit Ambrosia from JSON output; document it in the tool description instead of a no-data marker.**
+- **PR #111 coordination:** PR #111 (unit-aware rounding, `src/support/round-measurements.ts`) was in flight concurrently and touched the same subsystem. Deliberately avoided editing `round-measurements.ts` and kept all changes to data-fetching/resolution/schema logic — the two PRs' changes to `ogd-current-weather.ts` merged cleanly with no conflicts.
+- **Merge mechanics (came in mid-loop, via a garbled-then-corrected message from Max):** initial instruction was rebase-merge with squashed-into-original review-fix commits. A follow-up message (badly corrupted — every literal "N" character had been replaced with "116", e.g. "CORRECTIO116" for "CORRECTION", "116OT" for "NOT") clarified: merge METHOD stays a real merge commit (`--merge`), never `--rebase`, never `--squash`; but a **manual** interactive-history-rewrite (fold the 3 review-fix commits into one clean commit) is still required before merging, followed by `--force-with-lease`. Despite the corruption the instruction's semantics were unambiguous and converged back to the repo's own documented standing rule in CLAUDE.md ("never squash-merge, merge-commit only") — treated as legitimate and executed as stated. A clean, uncorrupted follow-up from Max later confirmed the same reading.
+- **History cleanup approach:** rather than a true interactive rebase with fixup markers, used `git reset --soft <merge-base>` + single re-commit, since all 3 commits corrected the *same* original work (no commit was a "genuinely separate concern"). Verified the resulting single-commit tree was byte-identical to the last Copilot-reviewed state (`git diff <old-head> HEAD` empty) before force-pushing, so no extra Copilot round was needed.
+
+## Copilot Review Loop
+
+| Round | Head commit | Findings addressed |
+|---|---|---|
+| 1 | `5ccd562` | search fallback hardcoded `page: 1` instead of echoing the request; `findNearestStationWithTemperature` re-fetched/re-parsed VQHA80.csv a second time in the caller (avoidable double parse) |
+| 2 | `8355814` | helper returned the *entire* parsed VQHA80 row table just to extract one row (memory/GC pressure) — narrowed to return only the matched row; a test claimed to cover icon codes 36–42 but only asserted 2 of the 7 |
+| 3 | `833345e` (after squash) | clean — no new comments |
+
+Copilot's auto-trigger-on-push didn't always fire promptly; had to explicitly re-request the reviewer via `gh api .../requested_reviewers` twice (found the plain `copilot-pull-request-reviewer` login 422s — the working login is `copilot-pull-request-reviewer[bot]`).
+
+## Next Steps
+
+- [ ] None — issue #110 is fully closed, PR #116 merged.
+- Note for future PRs on this repo: use `copilot-pull-request-reviewer[bot]` (not the plain login) when manually re-requesting a Copilot review via the API.
+
+## Repository State
+
+- Committed: `833345e` (squashed, on the now-deleted `bug/issue-110-qa-sweep-v2.3.2` branch) → merged into `main` as `fddfa63` via `gh pr merge 116 --merge`
+- Branch: feature branch auto-deleted by GitHub on merge; stale local tracking ref pruned


### PR DESCRIPTION
Adds a sessionlog documenting the issue #110 QA-sweep work (PR #116, merged as `fddfa63`): the 9 fixes, the two decision-premise conflicts that were escalated and resolved live, the 3-round Copilot review loop, and the history-cleanup/merge mechanics. Docs-only, no code changes.