### PR TITLE
feat(release): integrate meteoswiss-skills into the changesets release flow

### DIFF
--- a/.changeset/qa-sweep-issue-110-fixes.md
+++ b/.changeset/qa-sweep-issue-110-fixes.md
@@ -1,5 +1,5 @@
 ---
-"meteoswiss-mcp": minor
+"meteoswiss-mcp": major
 ---
 
 Fix nine findings from a 3-model QA sweep of v2.3.2 (issue #110):

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           title: 'Version Packages'
           commit: 'I: Version packages'
-          version: pnpm changeset version
+          # `pnpm run version` = `changeset version` + syncs meteoswiss-skills'
+          # bumped version into its plugin/marketplace manifests and SKILL.md
+          # + stamps release dates onto the new CHANGELOG headers.
+          version: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,13 +313,17 @@ Or create manually in `.changeset/`:
 Description of the change.
 ```
 
+For a **skill-facing change** (anything under `packages/meteoswiss-skills/`), add a `"meteoswiss-skills"` changeset the same way — it's a first-class changesets package, not tied to `meteoswiss-mcp`. A change that touches both packages should list both (bump each independently).
+
 **Automated flow:**
 1. PRs with changesets merge to `main`
-2. The "Version Packages" workflow creates/updates a PR that bumps `package.json` versions and generates `CHANGELOG.md`
+2. The "Version Packages" workflow runs `pnpm run version` (= `changeset version` + the skills manifest sync + CHANGELOG date stamping, see below) and creates/updates a PR that bumps `package.json` versions and generates `CHANGELOG.md`
 3. Merging the "Version Packages" PR finalizes the version bump
 4. Create a GitHub Release: `meteoswiss-mcp-vX.Y.Z` triggers npm + Docker publishing; `meteoswiss-skills-vX.Y.Z` triggers skill validation
 
 **Tag format:** `{package-name}-v{version}` (e.g., `meteoswiss-mcp-v2.1.0`, `meteoswiss-skills-v1.0.0`)
+
+**meteoswiss-skills version sync.** The skills package is also a Claude Code / Cursor plugin, so its version is mirrored in four files that changesets doesn't manage: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (`plugins[]`), `.cursor-plugin/plugin.json`, and each `skills/*/SKILL.md` frontmatter (`metadata.version`). `package.json` is the single source of truth; `scripts/sync-skill-manifest-versions.mjs` (run by the root `version` script, right after `changeset version`) propagates the bumped version into those mirrors. It's a no-op when nothing changed, so MCP-only releases are unaffected. Don't hand-edit those version fields — let the sync own them.
 
 **Not every PR needs a changeset.** Skip for: docs-only changes, CI config, dev tooling, test-only changes.
 

--- a/docs/sessionlogs/2026-07-11-skills-changesets-integration.md
+++ b/docs/sessionlogs/2026-07-11-skills-changesets-integration.md
@@ -1,0 +1,116 @@
+# Integrate meteoswiss-skills into the Changesets release flow
+
+**Date:** 2026-07-11
+**Model:** Claude Opus 4.8 (worktree `changeset-release-fix`, branch `infra/skills-changesets-release`)
+**PR:** [#123](https://github.com/eins78/meteoswiss-llm-tools/pull/123)
+
+## Motivation
+
+The Version Packages PR (#117) only ever released `meteoswiss-mcp`. Max wanted `meteoswiss-skills`
+to be a first-class release citizen too, modeled on how his `eins78/agent-skills` repo wires skills
+into changesets.
+
+## What agent-skills actually does (reference研究)
+
+Dispatched a research subagent to read `eins78/agent-skills` end to end. Key finding: it is **not a
+workspace** — one root `package.json`, and skills are just `skills/<name>/` directories whose version
+lives in `SKILL.md` frontmatter (`metadata.version`). Because changesets can't see individual skills
+in a single-package repo, agent-skills encodes per-skill bumps in an HTML comment inside each
+changeset body:
+
+```markdown
+---
+"@eins78/agent-skills": patch
+---
+Brief description
+<!--
+bumps:
+  skills:
+    skill-name: patch
+-->
+```
+
+Its root `version` script wraps changesets: `bump-skill-versions.sh` (parse the comments, bump each
+SKILL.md) → `changeset version` (root package + CHANGELOG) → `sync-versions.sh` (propagate root
+version into `plugin.json`/`cursor-plugin`/`marketplace.json`). Its `publish:` step is a bash script
+that creates git tags (`v3.1.0` + per-skill `pandoc@1.3.0`) and a GitHub Release — **no npm publish**;
+distribution is the git-based Claude Code plugin marketplace.
+
+## The gap here was smaller than agent-skills'
+
+meteoswiss is a **real pnpm workspace**. `meteoswiss-skills` is already a first-class changesets
+package (its `CHANGELOG.md` is changeset-generated; a `meteoswiss-skills-v1.0.0` tag exists), so the
+`<!-- bumps -->` hack is unnecessary — a plain `"meteoswiss-skills": patch` changeset frontmatter
+bumps its `package.json` natively (exactly what the pending #122 does).
+
+The only real gap: the skill is also a Claude Code / Cursor plugin, so its version is mirrored in four
+files changesets doesn't manage, all stuck at `1.0.0` while `package.json` would bump:
+`.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (`plugins[]`),
+`.cursor-plugin/plugin.json`, and `skills/*/SKILL.md` (`metadata.version`).
+(`meteoswiss-forecast-evals` is `private: true`, so changesets correctly ignores it.)
+
+## Decision: version-sync only (asked Max)
+
+agent-skills auto-creates tags + a GitHub Release in its `publish:` step. meteoswiss releases both
+packages manually. Surfaced this as the one real design choice; Max chose **version-sync only** —
+keep the manual release flow, just make `changeset version` sync the manifests. Consistent with his
+earlier "keep it manual" stance on the release pipeline.
+
+## Implementation
+
+Ported only the sync half of agent-skills' `version`-script wrap:
+
+- `scripts/sync-skill-manifest-versions.mjs` — treats `package.json` as the single source of truth and
+  propagates its version into the four mirrors via **targeted string edits** (find `"version": "<old>"`
+  → replace), preserving each file's formatting rather than reserializing (which would reflow inline
+  arrays like `keywords`). No-op when already in sync.
+- Root `version` script → `changeset version && node scripts/sync-skill-manifest-versions.mjs`
+  (the CHANGELOG date-stamping step below is appended too); and `version-packages.yml` now calls
+  `pnpm run version` instead of `pnpm changeset version`.
+- CLAUDE.md documents the skills-changeset convention + "don't hand-edit the mirror version fields".
+
+## Verification
+
+- Simulated bump (`package.json` → 1.0.1) then a full `pnpm run version` with a temp
+  `"meteoswiss-skills": patch` changeset: `package.json` + `CHANGELOG.md` → 1.0.1 and all four mirrors
+  → 1.0.1, diff limited to version lines only. MCP independently bumped 2.3.2 → 2.4.0 from the real
+  pending changesets. Reverted the test artifacts.
+- MCP-only path: sync reports `0 file(s) updated` → clean no-op, no spurious diffs.
+- `pnpm install --frozen-lockfile` green; `pnpm --filter meteoswiss-mcp run ci` 22 suites / 202 tests;
+  `pnpm --filter meteoswiss-skills test` green.
+
+## Interaction with #122
+
+#122 adds a `"meteoswiss-skills": patch` changeset. No conflict — once it merges, the next Version
+Packages run bumps `meteoswiss-skills 1.0.0 → 1.0.1` and the sync propagates it to every mirror.
+
+## Also in this PR: correct the #110 changeset bump (minor → major)
+
+`.changeset/qa-sweep-issue-110-fixes.md` was `"meteoswiss-mcp": minor`, but its body lists two
+explicit `**BREAKING:**` changes (`fetch` drops the duplicate `content` field; `search` drops the
+`pageSize` parameter). Per semver that's a `major`. Bumped it to `major`. `pnpm changeset status`
+(read-only) confirms `meteoswiss-mcp` now computes at major. Combined with #101's own `major`
+changeset on #122, the next MCP release is **3.0.0** (from 2.3.2), not 2.4.0. Cutting that release
+remains Max's call — this PR only fixes the changeset metadata.
+
+## Also in this PR: CHANGELOG date stamping
+
+`.changeset/config.json` uses `@changesets/cli/changelog`, which writes bare `## X.Y.Z` headers with
+no date. Added `scripts/stamp-changelog-dates.mjs` (wired into the root `version` script after the
+sync step) that rewrites each **newly-added** header to `## X.Y.Z - YYYY-MM-DD` — the exact
+unbracketed format the historical backfill (#124) uses, so past and future match.
+
+"Newly added" is detected via `git diff HEAD` restricted to CHANGELOG files, so it only stamps the
+header(s) *this* `changeset version` run introduced — never a pre-existing entry, and (critically)
+never a historical undated header lower in the file. It's idempotent: an already-dated header won't
+re-match, and a run with no bumps is a no-op.
+
+Verified in the same dry-run: the new `## 3.0.0` (mcp) and `## 1.0.1` (skills) headers came out as
+`## 3.0.0 - 2026-07-11` / `## 1.0.1 - 2026-07-11`, while the historical `## 2.3.2`/`## 2.3.1`/`## 2.3.0`
+and `## 1.0.0` headers were left bare/untouched.
+
+## Not done (deliberately)
+
+Per the chosen scope: no auto-tagging, no auto-GitHub-Release, no per-skill `<skill>@<version>` tags,
+no marketplace.json regeneration-from-scratch. The single skill/plugin doesn't warrant agent-skills'
+full machinery; revisit if the package grows to multiple independently-versioned skills.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "CC0-1.0",
   "scripts": {
     "changeset": "changeset",
-    "version": "changeset version"
+    "version": "changeset version && node scripts/sync-skill-manifest-versions.mjs"
   },
   "packageManager": "pnpm@10.34.5+sha512.a4ee05f2f73658255bd6a89859c065a45c28a57daefae2c893a168ee2b73168c37b91e83e57ea67654ad03f03031746430e8bce38e362e042605fb8abc80192e",
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "CC0-1.0",
   "scripts": {
     "changeset": "changeset",
-    "version": "changeset version && node scripts/sync-skill-manifest-versions.mjs"
+    "version": "changeset version && node scripts/sync-skill-manifest-versions.mjs && node scripts/stamp-changelog-dates.mjs"
   },
   "packageManager": "pnpm@10.34.5+sha512.a4ee05f2f73658255bd6a89859c065a45c28a57daefae2c893a168ee2b73168c37b91e83e57ea67654ad03f03031746430e8bce38e362e042605fb8abc80192e",
   "pnpm": {

--- a/scripts/stamp-changelog-dates.mjs
+++ b/scripts/stamp-changelog-dates.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// Stamp today's release date onto the version headers that `changeset version`
+// just added.
+//
+// `@changesets/cli/changelog` writes bare `## X.Y.Z` headers with no date. This
+// rewrites each NEWLY-ADDED one to `## X.Y.Z - YYYY-MM-DD` (unbracketed) — the
+// same format the historical-entry backfill (#124) applies, so past and future
+// entries match once both land. It runs after `changeset version` in the root
+// `version` script, alongside the skills manifest sync.
+//
+// "Newly added" is detected via `git diff HEAD` restricted to CHANGELOG files,
+// so it only ever touches the header(s) this run introduced — never a
+// pre-existing entry, and never a historical undated header lower in the file.
+// Combined with the bare-header match it is idempotent: an already-dated header
+// is left alone, and a run with no version bumps is a no-op.
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
+
+// A bare version header: `## 1.2.3` or `## 1.2.3-rc.1`, with NO trailing date.
+const BARE_HEADER = /^## (\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/;
+
+let diff;
+try {
+  // Restrict the diff to CHANGELOG files at the git level (not just in JS) so an
+  // unrelated dirty working tree can't bloat the output or trip maxBuffer.
+  diff = execFileSync('git', ['diff', 'HEAD', '--unified=0', '--', ':(glob)**/CHANGELOG.md'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  });
+} catch (err) {
+  console.warn(`stamp-changelog-dates: git diff failed, skipping (${err.message})`);
+  process.exit(0);
+}
+
+// Map each changed CHANGELOG file -> the set of version headers it newly added.
+const addedByFile = new Map();
+let currentFile = null;
+for (const line of diff.split('\n')) {
+  const fileMatch = line.match(/^\+\+\+ b\/(.+)$/);
+  if (fileMatch) {
+    currentFile = fileMatch[1].endsWith('CHANGELOG.md') ? fileMatch[1] : null;
+    continue;
+  }
+  if (!currentFile || !line.startsWith('+') || line.startsWith('+++')) continue;
+  const headerMatch = line.slice(1).match(BARE_HEADER);
+  if (headerMatch) {
+    if (!addedByFile.has(currentFile)) addedByFile.set(currentFile, new Set());
+    addedByFile.get(currentFile).add(headerMatch[1]);
+  }
+}
+
+let stamped = 0;
+for (const [relFile, versions] of addedByFile) {
+  const file = join(repoRoot, relFile);
+  let text = readFileSync(file, 'utf8');
+  for (const version of versions) {
+    // Match the still-bare header line only (idempotent: a dated header won't match).
+    const headerLine = new RegExp(`^## ${version.replace(/[.\-]/g, '\\$&')}$`, 'm');
+    if (headerLine.test(text)) {
+      text = text.replace(headerLine, `## ${version} - ${today}`);
+      console.log(`  ## ${version} -> ## ${version} - ${today}: ${relFile}`);
+      stamped++;
+    }
+  }
+  writeFileSync(file, text);
+}
+
+console.log(`stamp-changelog-dates: ${today} (${stamped} header(s) stamped)`);

--- a/scripts/sync-skill-manifest-versions.mjs
+++ b/scripts/sync-skill-manifest-versions.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// Propagate the meteoswiss-skills version into its plugin/marketplace manifests
+// and SKILL.md frontmatter.
+//
+// Changesets versions the `meteoswiss-skills` workspace package normally — it
+// bumps `packages/meteoswiss-skills/package.json` and writes the CHANGELOG. But
+// the skill is also a Claude Code / Cursor plugin whose version is mirrored in
+// four other files that changesets doesn't know about. This script treats
+// package.json as the single source of truth and syncs that version into the
+// mirrors via targeted string edits (preserving each file's formatting), so a
+// `changeset version` run updates the whole skills package consistently.
+//
+// It runs after `changeset version` in the root `version` script (see
+// package.json), alongside the CHANGELOG date-stamping step, and is a no-op when
+// everything is already in sync (e.g. an MCP-only release).
+
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const skillsPkgDir = join(repoRoot, 'packages', 'meteoswiss-skills');
+
+const pkg = JSON.parse(readFileSync(join(skillsPkgDir, 'package.json'), 'utf8'));
+const version = pkg.version;
+// Full semver (optional prerelease + build metadata), anchored — reject junk like `1.0.0foo`.
+const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+if (typeof version !== 'string' || !SEMVER.test(version)) {
+  throw new Error(`meteoswiss-skills package.json has an unexpected version: ${String(version)}`);
+}
+
+let changed = 0;
+
+/**
+ * Update a `"version": "..."` field in a JSON manifest via a targeted string
+ * replace (keeps the file's existing indentation/ordering intact).
+ *
+ * @param {string} relPath - path relative to the meteoswiss-skills package
+ * @param {(data: unknown) => string | undefined} selectCurrent - reads the current version
+ * @param {string} [anchorName] - if given, replace the first version field AFTER
+ *   the `"name": "<anchorName>"` entry rather than the first in the file (so a
+ *   nested entry — e.g. the meteoswiss-skills plugin inside marketplace.json's
+ *   `plugins` array — is targeted precisely even if another entry shares the same
+ *   version string). Matched whitespace-tolerantly, like the version field.
+ */
+function syncJsonVersion(relPath, selectCurrent, anchorName) {
+  const file = join(skillsPkgDir, relPath);
+  if (!existsSync(file)) {
+    console.warn(`  skip (missing): ${relPath}`);
+    return;
+  }
+  const text = readFileSync(file, 'utf8');
+  const current = selectCurrent(JSON.parse(text));
+  if (current === undefined) {
+    console.warn(`  skip (no version field): ${relPath}`);
+    return;
+  }
+  if (current === version) {
+    console.log(`  ok (already ${version}): ${relPath}`);
+    return;
+  }
+  let from = 0;
+  if (anchorName) {
+    const anchor = new RegExp(`"name"\\s*:\\s*"${anchorName.replace(/[.+\-]/g, '\\$&')}"`);
+    const anchorMatch = text.match(anchor);
+    if (!anchorMatch) {
+      throw new Error(`Could not find anchor "name": "${anchorName}" in ${relPath}`);
+    }
+    from = anchorMatch.index;
+  }
+  // Whitespace-tolerant `"version": "<current>"` so a reformatted JSON file
+  // (e.g. `"version":"1.0.0"`) doesn't break the release flow. Normalizes to `": "`.
+  const escaped = current.replace(/[.+\-]/g, '\\$&');
+  const field = new RegExp(`"version"\\s*:\\s*"${escaped}"`);
+  const match = text.slice(from).match(field);
+  if (!match) {
+    throw new Error(`Could not find "version": "${current}" in ${relPath} to update`);
+  }
+  const at = from + match.index;
+  writeFileSync(file, text.slice(0, at) + `"version": "${version}"` + text.slice(at + match[0].length));
+  console.log(`  ${current} -> ${version}: ${relPath}`);
+  changed++;
+}
+
+syncJsonVersion('.claude-plugin/plugin.json', (d) => d?.version);
+syncJsonVersion('.cursor-plugin/plugin.json', (d) => d?.version);
+syncJsonVersion(
+  '.claude-plugin/marketplace.json',
+  (d) => d?.plugins?.find((p) => p?.name === 'meteoswiss-skills')?.version,
+  'meteoswiss-skills',
+);
+
+// SKILL.md frontmatter carries a mirrored `metadata.version` for every skill in
+// the package. All skills share the package version under the single-package model.
+const skillsDir = join(skillsPkgDir, 'skills');
+if (existsSync(skillsDir)) {
+  const versionLine = /(\n[ \t]*version:[ \t]*)([^\n]+)/;
+  for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const rel = `skills/${entry.name}/SKILL.md`;
+    const file = join(skillsDir, entry.name, 'SKILL.md');
+    if (!existsSync(file)) continue;
+    const text = readFileSync(file, 'utf8');
+    const frontmatter = text.match(/^---\n([\s\S]*?)\n---/);
+    if (!frontmatter) {
+      console.warn(`  skip (no frontmatter): ${rel}`);
+      continue;
+    }
+    const match = frontmatter[1].match(versionLine);
+    if (!match) {
+      console.warn(`  skip (no metadata.version): ${rel}`);
+      continue;
+    }
+    const current = match[2].trim();
+    if (current === version) {
+      console.log(`  ok (already ${version}): ${rel}`);
+      continue;
+    }
+    const newFrontmatter = frontmatter[1].replace(versionLine, `$1${version}`);
+    writeFileSync(file, text.replace(frontmatter[1], newFrontmatter));
+    console.log(`  ${current} -> ${version}: ${rel}`);
+    changed++;
+  }
+}
+
+console.log(`sync-skill-manifest-versions: meteoswiss-skills@${version} (${changed} file(s) updated)`);


### PR DESCRIPTION
## Summary

Makes **meteoswiss-skills** a first-class citizen of the changesets release flow, modeled on `eins78/agent-skills`.

Changesets already versioned the skills **package.json** (it's a non-private workspace package — its `CHANGELOG.md` is changeset-generated and a `meteoswiss-skills-v1.0.0` tag exists). But the skill is also a **Claude Code / Cursor plugin** whose version is mirrored in four files changesets doesn't manage, all stuck at `1.0.0`:

- `.claude-plugin/plugin.json` → `.version`
- `.claude-plugin/marketplace.json` → `.plugins[].version`
- `.cursor-plugin/plugin.json` → `.version`
- `skills/*/SKILL.md` frontmatter → `metadata.version`

So a skills bump drifted out of sync across the manifests.

## How this compares to agent-skills

`agent-skills` is a **single-package** repo, so it can't let changesets see individual skills — it uses a `<!-- bumps: skills: name: patch -->` HTML-comment hack parsed by a custom `bump-skill-versions.sh`. meteoswiss is a **real pnpm workspace** where `meteoswiss-skills` is already a first-class changesets package, so a plain `"meteoswiss-skills": patch` changeset frontmatter bumps it natively (exactly what #122 does). Only the **manifest version-sync** half of agent-skills' `version`-script wrap needed porting.

Per the agreed scope, this is **version-sync only** — the release step stays manual and unchanged (cut a `meteoswiss-skills-vX.Y.Z` GitHub Release → `release-skill.yml` validates), same as MCP. No auto-tagging/auto-Release was added.

## Changes

- **`scripts/sync-skill-manifest-versions.mjs`** — reads the (changesets-bumped) `meteoswiss-skills` `package.json` version and propagates it into the four mirror fields via targeted string edits that preserve each file's formatting. No-op when already in sync.
- **Root `version` script** → `changeset version && node scripts/sync-skill-manifest-versions.mjs`; **`version-packages.yml`** now calls `pnpm run version` instead of `pnpm changeset version`. So the Version Packages PR bumps the whole skills package coherently.
- **CLAUDE.md** documents the skills-changeset convention and the sync mechanism.

## Verification

- **End-to-end:** a temp `"meteoswiss-skills": patch` changeset run through `pnpm run version` bumped `package.json` + `CHANGELOG.md` to `1.0.1` and synced all four mirrors to `1.0.1` (formatting preserved — only version lines changed); MCP independently bumped `2.3.2 → 2.4.0` from the real pending changesets. Reverted after.
- **MCP-only path:** sync is a clean no-op (0 files changed) → no spurious diffs on MCP-only releases.
- `pnpm install --frozen-lockfile` passes (no dep changes).
- `pnpm --filter meteoswiss-mcp run ci` — 22 suites, 202 tests pass (1 pre-existing skip).
- `pnpm --filter meteoswiss-skills test` (what `release-skill.yml` runs) passes.

## Interaction with #122

PR #122 adds `.changeset/skills-hourly-multiseries-parity.md` (`"meteoswiss-skills": patch`). No conflict — this PR only adds the sync tooling. Once #122 merges, the next Version Packages run bumps `meteoswiss-skills 1.0.0 → 1.0.1` and the sync propagates it to all mirrors automatically.

A sessionlog is included in this PR per standing policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Note: also corrects the #110 changeset bump (minor → major)

This PR also changes `.changeset/qa-sweep-issue-110-fixes.md` from `"meteoswiss-mcp": minor` to `major`, because its body documents two explicit **BREAKING** changes (`fetch` drops the duplicate `content` field; `search` drops the `pageSize` parameter) — semver requires major. Combined with #101's own `major` changeset (on #122), the next `meteoswiss-mcp` release is **3.0.0**, not 2.4.0. (Surfaced by Copilot review; cutting the release remains Max's call.)
