### PR TITLE
docs: backfill and correct meteoswiss-mcp CHANGELOG history

### DIFF
--- a/docs/sessionlogs/2026-07-11-changelog-backfill.md
+++ b/docs/sessionlogs/2026-07-11-changelog-backfill.md
@@ -1,0 +1,74 @@
+# CHANGELOG Backfill & Correction (meteoswiss-mcp)
+
+**Date:** 2026-07-11
+**Model:** Claude Opus 4.8 (worktree `changelog-backfill`, branch `worktree-changelog-backfill`)
+**PR:** _(see PR link once opened)_
+
+## Motivation
+
+`packages/meteoswiss-mcp/CHANGELOG.md` only covered releases from 2.1.0 up to 2.3.2, and even
+that range had drifted out of sync with the actual git tags and published GitHub release notes.
+The goal: reconstruct the missing historical entries from the git/PR record, in a standalone PR,
+without touching changesets config, the release workflow, or `package.json` versions (that
+skills↔changesets work is owned by a parallel branch — `infra/skills-changesets-release`).
+
+## What the record showed
+
+Surveying `git tag`, `gh release list/view`, and the changelog revealed **five** released
+versions with no correct entry: `1.0.0`, `2.0.0`, `2.0.1`, `2.0.2`, and `2.2.1`. RC pre-release
+tags and the `meteoswiss-skills` package (only `1.0.0` released, already in its own changelog)
+were confirmed out of scope.
+
+## Design decision: the 2.2.0 / 2.2.1 / 2.3.0 tangle was a misfiling, not just a gap
+
+The `## 2.2.0` section listed two blocks — a Tier-1 OGD features minor (`615eb7a`) and a
+fetch/pollen/forecast patch (`32373ae`) — and there was no `## 2.2.1` heading at all. Cross-
+checking each hash against commit dates and the published GitHub release notes proved the whole
+region was mislabeled:
+
+| Version | Should contain | Was showing |
+|---------|----------------|-------------|
+| 2.3.0   | **Minor:** Tier-1 features (`615eb7a`) + **Patch:** location resolver (`de9c937`) | only the patch |
+| 2.2.1   | **Patch:** fetch/pollen/forecast fixes (`32373ae`) | *(missing — folded into 2.2.0)* |
+| 2.2.0   | **Minor:** opt-in Prometheus metrics (`ff0cf3b`, #58) | Tier-1 + fetch fixes (both wrong) |
+
+The decisive evidence was **commit-authoring dates**: `615eb7a` (Tier-1) was authored
+`2026-04-08 16:52`, two minutes before tag `2.3.0-rc.1` (`16:54`) and a full five days *after*
+tag `2.2.0` (`2026-04-03`). A commit authored April 8 physically cannot be in an April 3 release,
+regardless of its "for v2.2.0 minor release" commit message. Three independent signals agreed:
+commit dates, GitHub release notes (2.2.0=metrics, 2.2.1=fetch, 2.3.0=resolver), and semver
+bump arithmetic (every bump now has a matching change of the right type).
+
+## What was done
+
+- **Relocated verbatim** (exact hashes + wording preserved, so the diff reads as cut/paste):
+  - Tier-1 block (`615eb7a`) → new `### Minor Changes` under `## 2.3.0`, above the existing
+    `de9c937` patch.
+  - Fetch-fixes block (`32373ae`) → new `## 2.2.1`.
+- **Wrote the genuinely-new 2.2.0 entry** — opt-in Prometheus metrics (`ff0cf3b`, #58) — from
+  the tag contents and GitHub release notes.
+- **Backfilled the four old versions** (`1.0.0`, `2.0.0`, `2.0.1`, `2.0.2`), each anchored to
+  its real tag commit SHA for verifiability:
+  - `1.0.0` (`74b8c37`) — initial MVP: `meteoswissWeatherReport`, DE/EN/FR/IT, HTTP/SSE + Docker.
+  - `2.0.0` (`d6b1c62`, #43) — OGD rewrite, monorepo, new tool set, `meteoswissWeatherReport`
+    removed, SSE→Streamable HTTP, Zod 4.
+  - `2.0.1` (`63f6f7f`, #50) — automated release pipeline (npm OIDC + multi-arch GHCR), npm
+    package size fix.
+  - `2.0.2` (`a976037`) — MCP Registry metadata + registration.
+
+## Format & accuracy notes
+
+- Mirrors the existing **changesets** style (`## version` → `### Major/Minor/Patch Changes` →
+  `- <sha>: …`), **not** Keep-a-Changelog `Added/Changed/Fixed` — the file was never in that
+  style. `1.0.0` and `2.0.x` predate changesets (removed in #50, re-added later), so they never
+  had changeset hashes; the tag-commit SHA is used as a real, verifiable anchor instead.
+- Marketing prose from the GitHub release pages (taglines, quick-start blocks, tool tables) was
+  distilled to factual bullets. Only claims supported by the git/PR/release record were kept.
+- Because `changeset version` only *prepends* new sections below the H1 and never rewrites
+  existing ones, these hand-authored historical entries are safe from being clobbered by future
+  automated releases.
+
+## Confidence
+
+All ten versions reconstructed with high confidence — every entry is triangulated against commit
+dates, GitHub release notes, and semver bump type. No version was left uncertain.

--- a/docs/sessionlogs/2026-07-11-changelog-backfill.md
+++ b/docs/sessionlogs/2026-07-11-changelog-backfill.md
@@ -72,3 +72,18 @@ bump arithmetic (every bump now has a matching change of the right type).
 
 All ten versions reconstructed with high confidence — every entry is triangulated against commit
 dates, GitHub release notes, and semver bump type. No version was left uncertain.
+
+## Follow-up: dated version headers
+
+Per Max's request, every version header was changed from bare `## X.Y.Z` to
+`## X.Y.Z - YYYY-MM-DD` using the tag creation dates
+(`git tag --format='%(refname:short) %(creatordate:short)'`), unbracketed to match the
+changesets header style. This keeps the past entries (hand-authored here) consistent with the
+format %6's automation will apply to future releases.
+
+Dates applied: 2.3.2 → 2026-04-20; 2.3.1 / 2.3.0 → 2026-04-18; 2.2.1 / 2.2.0 → 2026-04-03;
+2.1.0 / 2.0.2 / 2.0.1 / 2.0.0 / 1.0.0 → 2026-03-29.
+
+One caveat worth recording: `1.0.0`'s *tag* date is 2026-03-29 (the tags were recreated during
+the monorepo restructure), whereas the original MVP was published 2025-06-09. Tag dates were
+used as instructed, so the header reads 2026-03-29.

--- a/packages/meteoswiss-mcp/CHANGELOG.md
+++ b/packages/meteoswiss-mcp/CHANGELOG.md
@@ -14,6 +14,14 @@
 
 ## 2.3.0
 
+### Minor Changes
+
+- 615eb7a: Add Tier 1 OGD features: SMN-precip stations, climate data tool, visual observations.
+  - **SMN-precip**: Merge ~248 precipitation-only stations into meteoswissCurrentWeather (per-station CSV fallback)
+  - **meteoswissClimateData**: New tool for NBCN homogeneous climate series (29 climate + 46 precip stations, daily/monthly/yearly)
+  - **Visual observations**: Enrich currentWeather with cloud cover, fog, rain, snowfall, hail, snow coverage for 8 OBS stations
+  - **CSV parser**: Replace custom parser with csv-parse/sync library
+
 ### Patch Changes
 
 - de9c937: Fix location resolver robustness across all MCP tools. Non-Swiss inputs, invalid station codes, and gibberish now return helpful errors instead of silently resolving to wrong Swiss locations.
@@ -26,15 +34,7 @@
   - **OBS visual observations**: Boolean fields (`has_rain`, `has_snowfall`, etc.) always return `true`/`false` instead of being stripped when MeteoSwiss reports "-" (not observed)
   - **`fetch` tool**: Revert unintentional breaking parameter rename — `id` reverted to `url`
 
-## 2.2.0
-
-### Minor Changes
-
-- 615eb7a: Add Tier 1 OGD features: SMN-precip stations, climate data tool, visual observations.
-  - **SMN-precip**: Merge ~248 precipitation-only stations into meteoswissCurrentWeather (per-station CSV fallback)
-  - **meteoswissClimateData**: New tool for NBCN homogeneous climate series (29 climate + 46 precip stations, daily/monthly/yearly)
-  - **Visual observations**: Enrich currentWeather with cloud cover, fog, rain, snowfall, hail, snow coverage for 8 OBS stations
-  - **CSV parser**: Replace custom parser with csv-parse/sync library
+## 2.2.1
 
 ### Patch Changes
 
@@ -45,8 +45,49 @@
   - **forecast:** Filter out past dates before slicing to requested days count
   - **search:** Document upstream pagination overlap and date-asc sort behavior
 
+## 2.2.0
+
+### Minor Changes
+
+- ff0cf3b: Add opt-in Prometheus metrics via `prom-client` (#58). Set `METRICS_ENABLED=true` to expose a standard `/metrics` endpoint; when unset or `false` (default), `/metrics` returns 404 and all recording functions are no-ops.
+  - **Metrics exposed**: `mcp_tool_calls_total{tool_name}` (counter), `mcp_tool_call_duration_seconds{tool_name}` (latency histogram), `mcp_active_sessions` (gauge), `mcp_requests_total{method}` (HTTP request counter), and `nodejs_*` runtime metrics (memory, GC, event loop)
+  - **Privacy**: No user data is collected — only tool names, HTTP methods, and session counts
+
 ## 2.1.0
 
 ### Minor Changes
 
 - 0ba372a: Add weather icon SVG URLs to forecast responses. Each daily forecast now includes a `weather_icon_url` field linking to the official MeteoSwiss SVG pictogram. The skill documentation is updated with the URL pattern.
+
+## 2.0.2
+
+### Patch Changes
+
+- a976037: Add MCP Registry metadata (`mcpName` + `server.json`) and register with the official MCP Registry.
+
+## 2.0.1
+
+### Patch Changes
+
+- 63f6f7f: Add an automated GitHub Actions release pipeline (#50). Publishes to npm via Trusted Publishers (OIDC, no tokens) and builds multi-platform Docker images (amd64 + arm64) to GHCR. Also fixes the published npm package size (65 kB, previously 81 MB) and adapts the Docker build and release workflow to the monorepo layout.
+
+## 2.0.0
+
+### Major Changes
+
+- d6b1c62: Complete rewrite on MeteoSwiss Open Government Data (OGD) — the same data powering the MeteoSwiss app and website (#43).
+  - **Monorepo restructure** under `meteoswiss-llm-tools`, ready for future packages
+  - **New tools**: `meteoswissLocalForecast` (multi-day forecasts for ~6000 Swiss locations by postal code, station, or place name), `meteoswissCurrentWeather` (real-time measurements from ~160 automatic weather stations), `meteoswissStations` (station discovery and search), `meteoswissPollenData` (pollen data from ~15 monitoring stations), plus `search` and `fetch` for MeteoSwiss website content
+  - **Removed** the region-based `meteoswissWeatherReport` tool
+  - **Transport**: Migrate from SSE to MCP Streamable HTTP (SDK 1.28+)
+  - **Dependencies**: Upgrade to Zod 4
+
+## 1.0.0
+
+### Major Changes
+
+- 74b8c37: First stable release — MCP server for MeteoSwiss weather data.
+  - **`meteoswissWeatherReport`** tool: weather reports for Swiss regions (north / south / west)
+  - Multi-language support (DE, EN, FR, IT)
+  - HTTP/SSE transport with `mcp-remote` integration
+  - Docker support and a homepage with installation instructions

--- a/packages/meteoswiss-mcp/CHANGELOG.md
+++ b/packages/meteoswiss-mcp/CHANGELOG.md
@@ -1,18 +1,18 @@
 # meteoswiss-mcp
 
-## 2.3.2
+## 2.3.2 - 2026-04-20
 
 ### Patch Changes
 
 - 7eb1e59: Restore ChatGPT Deep Research / Connectors compatibility for the `fetch` tool. The v2.3.1 release renamed the `fetch` argument from `id` to `url`, which broke the canonical contract that ChatGPT (and the OpenAI Responses API Deep Research models) expects. This release renames it back to `id`, adds the canonical `text` and top-level `url` fields to the `fetch` response, keeps `content` as a back-compat alias of `text`, and adds an integration test suite + tool-manifest snapshot to prevent the regression from recurring. See `docs/plans/2026-04-19-chatgpt-fetch-compat.md` for the full investigation and references.
 
-## 2.3.1
+## 2.3.1 - 2026-04-18
 
 ### Patch Changes
 
 - fa7ab7b: Expose `meteoswiss_mcp_build_info{version, node_version}` Prometheus gauge for version observability. Enables the Grafana dashboard to show the deployed version of each environment (TEST and PROD) at a glance without querying MCP endpoints.
 
-## 2.3.0
+## 2.3.0 - 2026-04-18
 
 ### Minor Changes
 
@@ -34,7 +34,7 @@
   - **OBS visual observations**: Boolean fields (`has_rain`, `has_snowfall`, etc.) always return `true`/`false` instead of being stripped when MeteoSwiss reports "-" (not observed)
   - **`fetch` tool**: Revert unintentional breaking parameter rename — `id` reverted to `url`
 
-## 2.2.1
+## 2.2.1 - 2026-04-03
 
 ### Patch Changes
 
@@ -45,7 +45,7 @@
   - **forecast:** Filter out past dates before slicing to requested days count
   - **search:** Document upstream pagination overlap and date-asc sort behavior
 
-## 2.2.0
+## 2.2.0 - 2026-04-03
 
 ### Minor Changes
 
@@ -53,25 +53,25 @@
   - **Metrics exposed**: `mcp_tool_calls_total{tool_name}` (counter), `mcp_tool_call_duration_seconds{tool_name}` (latency histogram), `mcp_active_sessions` (gauge), `mcp_requests_total{method}` (HTTP request counter), and `nodejs_*` runtime metrics (memory, GC, event loop)
   - **Privacy**: No user data is collected — only tool names, HTTP methods, and session counts
 
-## 2.1.0
+## 2.1.0 - 2026-03-29
 
 ### Minor Changes
 
 - 0ba372a: Add weather icon SVG URLs to forecast responses. Each daily forecast now includes a `weather_icon_url` field linking to the official MeteoSwiss SVG pictogram. The skill documentation is updated with the URL pattern.
 
-## 2.0.2
+## 2.0.2 - 2026-03-29
 
 ### Patch Changes
 
 - a976037: Add MCP Registry metadata (`mcpName` + `server.json`) and register with the official MCP Registry.
 
-## 2.0.1
+## 2.0.1 - 2026-03-29
 
 ### Patch Changes
 
 - 63f6f7f: Add an automated GitHub Actions release pipeline (#50). Publishes to npm via Trusted Publishers (OIDC, no tokens) and builds multi-platform Docker images (amd64 + arm64) to GHCR. Also fixes the published npm package size (65 kB, previously 81 MB) and adapts the Docker build and release workflow to the monorepo layout.
 
-## 2.0.0
+## 2.0.0 - 2026-03-29
 
 ### Major Changes
 
@@ -82,7 +82,7 @@
   - **Transport**: Migrate from SSE to MCP Streamable HTTP (SDK 1.28+)
   - **Dependencies**: Upgrade to Zod 4
 
-## 1.0.0
+## 1.0.0 - 2026-03-29
 
 ### Major Changes
 


### PR DESCRIPTION
## Summary

Backfills the missing historical entries in `packages/meteoswiss-mcp/CHANGELOG.md` and **aligns the file with the published GitHub release notes and actual tag contents**. Along the way it corrects a misfiling where a changeset authored **April 8** had been folded into the **April 3** 2.2.0 release.

Docs-only. No `.changeset/config`, release workflow, or `package.json` versions are touched (that skills/changesets work lives on a separate branch, so this avoids merge conflicts).

## Backfilled versions

Reconstructed from the git/PR/release record, each anchored to a real tag/PR commit:

| Version | Anchor | Entry |
|---------|--------|-------|
| `1.0.0` | `74b8c37` | Initial MVP — `meteoswissWeatherReport`, DE/EN/FR/IT, HTTP/SSE + Docker |
| `2.0.0` | `d6b1c62` (#43) | OGD rewrite, monorepo, new tool set, `meteoswissWeatherReport` removed, SSE→Streamable HTTP, Zod 4 |
| `2.0.1` | `63f6f7f` (#50) | Automated release pipeline (npm OIDC + multi-arch GHCR), npm package size fix |
| `2.0.2` | `a976037` | MCP Registry metadata + registration |
| `2.2.0` | `ff0cf3b` (#58) | Opt-in Prometheus metrics via `prom-client` |

## Correction: the 2.2.0 / 2.2.1 / 2.3.0 tangle

The existing `## 2.2.0` section listed two blocks that belong to *other* releases, and there was no `## 2.2.1` heading at all. The changelog had diverged from the published releases:

| Version | Should contain | Was showing |
|---------|----------------|-------------|
| 2.3.0 | **Minor:** Tier-1 features (`615eb7a`) + **Patch:** location resolver (`de9c937`) | only the patch |
| 2.2.1 | **Patch:** fetch/pollen/forecast fixes (`32373ae`) | *(missing — folded into 2.2.0)* |
| 2.2.0 | **Minor:** opt-in Prometheus metrics (`ff0cf3b`, #58) | Tier-1 + fetch fixes (both wrong) |

**Decisive evidence — commit dates are physics:** `615eb7a` (Tier-1 features) was authored `2026-04-08 16:52`, two minutes before tag `2.3.0-rc.1` and five days *after* tag `2.2.0` (`2026-04-03`). A commit authored April 8 cannot be in an April 3 release, whatever its "for v2.2.0" commit message says. Three signals agree: commit dates, GitHub release notes (2.2.0=metrics, 2.2.1=fetch, 2.3.0=resolver), and semver bump arithmetic.

The Tier-1 (`615eb7a`) and fetch-fixes (`32373ae`) blocks are **relocated verbatim** — exact hashes and wording preserved — so the diff reads as cut/paste + relocate, not a rewrite.

## Notes

- Mirrors the existing **changesets** style, not Keep-a-Changelog. `1.0.0`/`2.0.x` predate changesets, so the tag-commit SHA is used as the verifiable anchor.
- Only claims supported by the git/PR/release record; GitHub marketing prose distilled to factual bullets.
- `changeset version` only *prepends* new sections below the H1, so these historical entries are safe from future automated releases.
- `meteoswiss-skills` (only `1.0.0` released) already has a complete changelog — out of scope.

Sessionlog: `docs/sessionlogs/2026-07-11-changelog-backfill.md` (included in this PR per standing policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
