### PR TITLE
F: registerTool() + Zod output schemas for all 7 tools (parity STEP A)

### DIFF
--- a/.changeset/register-tool-output-schemas.md
+++ b/.changeset/register-tool-output-schemas.md
@@ -1,0 +1,5 @@
+---
+"meteoswiss-mcp": minor
+---
+
+All 7 tools now declare Zod output schemas and return MCP `structuredContent` alongside the JSON text content. Tool registrations migrated from the deprecated `server.tool()` to `registerTool()`, so `tools/list` now advertises each tool's full output shape (with per-field descriptions) in addition to its input schema, and the SDK validates every response against the declared schema at runtime. Response shapes are unchanged — the previously hand-written TypeScript response types are now derived from the schemas via `z.infer`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,9 +201,9 @@ Prefer comprehensive JSDoc/TSDoc comments for implementation details and README 
 ## MCP Tool Implementation
 
 When implementing MCP tools:
-1. Define Zod schema for parameters in `src/schemas/`
+1. Define Zod schemas in `src/schemas/` — both the input params schema and the output (response) schema; export response types via `z.infer` so data-layer return types stay in sync with the declared schema
 2. Implement tool logic in `src/tools/`
-3. Register tool in `src/server.ts` using `server.tool()`
+3. Register tool in `src/server.ts` using `server.registerTool(name, { description, inputSchema, outputSchema }, handler)` — declare the output schema so `tools/list` advertises it, and return `structuredContent` (the SDK validates it against the output schema on every call; the plain `content` JSON text stays alongside it for compatibility)
 4. Add integration tests in `test/integration/`
 5. Document tool behavior and parameters
 

--- a/docs/sessionlogs/2026-07-11-register-tool-output-schemas.md
+++ b/docs/sessionlogs/2026-07-11-register-tool-output-schemas.md
@@ -1,0 +1,101 @@
+# registerTool() + Zod Output Schemas for All 7 Tools
+
+**Date:** 2026-07-11
+**Model:** Claude Fable 5 (worktree `skills-mcp-parity`, branch `feature/register-tool-output-schemas`)
+**Plan:** STEP A of `docs/plans/2026-07-11-skills-mcp-parity.md` (on PR #119) — resolved decision 1
+**Related sessionlog:** `2026-07-11-skills-mcp-parity-proposal.md` (the parity plan's own log, rounds 1–4)
+
+## Motivation
+
+Prerequisite sub-task of the skills↔MCP parity plan: the parity lint's source of truth is the
+generated `tools/list` output, and Max decided (PR #119 review, decision 1) that **output shape
+must be part of that generated surface**, not just input params. Today's `server.tool()`
+registrations (deprecated in SDK 1.28) declare only input schemas; response shapes were hand-written
+TypeScript types invisible to the protocol. This PR migrates all 7 tools to `registerTool()` with
+declared Zod `outputSchema`, so `tools/list` advertises the full contract and the SDK validates
+every response at runtime. Independently valuable beyond the parity plan: MCP clients get
+machine-readable output shapes with per-field descriptions, and `structuredContent` responses.
+
+## What changed
+
+- **Schemas** (`src/schemas/`): each tool's response type converted from a hand-written TS type to
+  a Zod schema, with the exported type names preserved via `z.infer` aliases — zero churn for
+  importers, and the compiler verifies the schemas structurally match what the data layer actually
+  returns (data functions are annotated with these same type names). The rich JSDoc semantics
+  (nullability rules, station-vs-postal-code sourcing caveats, the `hourly: null` vs `[]`
+  distinction) moved into `.describe()` calls so they are now part of the wire-visible schema —
+  which is exactly what the parity lint (STEP B) will consume.
+  - `ogd-local-forecast.ts`: `HourlyEntrySchema`, `DailyForecastSchema`, `LocalForecastResponseSchema`
+  - `ogd-current-weather.ts`: `MeasurementValueSchema`, `CurrentWeatherResponseSchema`
+  - `ogd-station-list.ts`: `StationListEntrySchema`, `StationListResponseSchema`
+  - `ogd-pollen-data.ts`: `PollenMeasurementSchema` (discriminated union on `status`),
+    `StationPollenDataSchema`, `PollenDataResponseSchema`
+  - `ogd-climate-data.ts`: `ClimateMeasurementSchema`, `ClimateDataResponseSchema`
+  - `meteoswiss-search.ts`: `SearchResultItemSchema`, `SearchResultsSchema` (moved from
+    `data/meteoswiss-search-data.ts`, which now re-exports the types)
+  - `meteoswiss-fetch.ts`: `ContentResponseSchema` (moved from `data/meteoswiss-content-data.ts`)
+- **`src/server.ts`**: all 7 registrations migrated
+  `server.tool(name, desc, shape, handler)` → `server.registerTool(name, { description,
+  inputSchema, outputSchema }, handler)`. Descriptions unchanged verbatim. Every success path now
+  returns `structuredContent` alongside the existing JSON text `content` (kept for compatibility).
+  Error paths unchanged (`isError: true`, content-only) — verified in the installed SDK source that
+  `validateToolOutput` explicitly skips validation for `isError` results.
+- **`src/tools/meteoswiss-fetch.ts`**: return type tightened `Promise<unknown>` →
+  `Promise<ContentResponse>` (needed for typed `structuredContent`; also better per repo standards).
+- **`CLAUDE.md`**: the "MCP Tool Implementation" checklist now describes the `registerTool()` +
+  output-schema + `structuredContent` pattern.
+- **Changeset**: `register-tool-output-schemas.md`, minor bump (additive; response shapes unchanged).
+
+## Decisions and rationale
+
+- **`z.infer` aliases instead of keeping parallel TS types**: the data layer's return-type
+  annotations reference the same exported names, so `tsc` proves schema↔runtime-shape equivalence at
+  compile time. `tsc` passed on the first run after conversion — the schemas are exact structural
+  matches of the old types.
+- **Error results stay content-only**: SDK 1.28's `validateToolOutput` returns early on
+  `result.isError` (read the installed `dist/esm/server/mcp.js`, not assumed), so no
+  `structuredContent` is required or emitted on error paths.
+- **Descriptions into `.describe()`**: deliberate for the parity plan — output-field semantics are
+  now machine-extractable from `tools/list` instead of living only in source comments.
+- **No `title`/`annotations`**: out of scope; pure migration plus output schemas.
+
+## Verification
+
+- `pnpm run fix && pnpm run ci` green: tsc lint, eslint, build, jest — 22 suites, 205 passed,
+  1 pre-existing skip (documented macOS port-mapping flake).
+- The integration suite runs through a real MCP client harness (`test/integration/mcp-client.ts` →
+  `client.callTool(...)`), so the SDK's output validation executed against fixture data for every
+  tool call in those tests — runtime proof the declared schemas accept real responses.
+- Direct in-process probe (`createServer()` → `InMemoryTransport` → `Client`): all 7 tools now
+  advertise `outputSchema` in `tools/list` (verified field lists per tool), and a live
+  `callTool('meteoswissStations', { canton: 'ZH', limit: 3 })` returned validated
+  `structuredContent` (`total: 4`, 3 stations).
+
+## Result
+
+- Branch `feature/register-tool-output-schemas` (off `origin/main` at `7d9879b`), PR to `main`.
+- STEP B (`infra/skills-parity-lint`) is blocked on this landing.
+
+## Copilot review fixes
+
+Copilot's automated review found one real issue, fixed:
+
+1. **`pageSize` description overclaimed.** The new protocol-visible describe() text said "fixed at
+   10 by the upstream API", but the implementation sets `pageSize: results.length` (fewer on the
+   last page, `0` on the empty/error path). Verified against `meteoswiss-search-data.ts` before
+   accepting, then reworded to "Number of items in `results` for this page — at most 10 (the
+   upstream API pages by a fixed 10), fewer on the last page". `pnpm run fix && pnpm run ci`
+   re-run green (22 suites, 205 passed, 1 pre-existing skip).
+
+## Delivery
+
+Max pre-authorized the pipeline (no per-PR merge approval needed). Delivery per the standard
+policy: Copilot loop run to convergence (round 2 re-review: "reviewed 14 out of 14 changed files
+… generated no new comments"), the review-fix commit rebase-folded into the feature commit
+(single-commit history, `--force-with-lease`), CI green awaited on the rebased head, then merged
+with a merge commit (no squash).
+
+## Pending / follow-ups
+
+- [ ] STEP B (`infra/skills-parity-lint`): the parity lint consumes the now-complete generated
+      tool inventory.

--- a/packages/meteoswiss-mcp/src/data/meteoswiss-content-data.ts
+++ b/packages/meteoswiss-mcp/src/data/meteoswiss-content-data.ts
@@ -8,7 +8,9 @@ import { gfm } from 'turndown-plugin-gfm';
 import { fetchHtml, HttpRequestError } from '../support/http-communication.js';
 import { debugData } from '../support/logging.js';
 import { expandWebComponents } from './meteoswiss-web-components.js';
-import type { FetchMeteoSwissContentInput } from '../schemas/meteoswiss-fetch.js';
+import type { ContentResponse, FetchMeteoSwissContentInput } from '../schemas/meteoswiss-fetch.js';
+
+export type { ContentResponse } from '../schemas/meteoswiss-fetch.js';
 
 // Test fixtures location
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -45,31 +47,12 @@ const turndownService = new TurndownService({
 // Add GFM plugin for better markdown support (tables, strikethrough, task lists)
 turndownService.use(gfm);
 
-/**
- * Content response structure.
- *
- * Field naming follows the ChatGPT Deep Research MCP contract:
- * `id`, `title`, `text`, `url`, `metadata`. Prior to v2.4.0 this response
- * also included a `content` field duplicating `text` byte-for-byte; it was
- * removed as a token-cost fix (issue #110, BUG-2) — `text` is canonical.
- */
-export interface ContentResponse {
-  id: string;
-  title?: string;
-  /** Canonical body field (matches ChatGPT Deep Research spec). */
-  text: string;
-  format: 'markdown' | 'text';
-  /** Canonical URL field (matches ChatGPT Deep Research spec). For this server `url === id`. */
-  url: string;
-  metadata?: {
-    url: string;
-    language?: string;
-    lastModified?: string;
-    contentType?: string;
-    keywords?: string[];
-    description?: string;
-  };
-}
+// ContentResponse now lives in ../schemas/meteoswiss-fetch.ts as a Zod schema
+// (ContentResponseSchema) so the fetch tool can declare it as its MCP outputSchema.
+// Field naming follows the ChatGPT Deep Research MCP contract: `id`, `title`,
+// `text`, `url`, `metadata`. Prior to v2.4.0 this response also included a
+// `content` field duplicating `text` byte-for-byte; it was removed as a
+// token-cost fix (issue #110, BUG-2) — `text` is canonical.
 
 /**
  * Fetch MeteoSwiss content by ID.

--- a/packages/meteoswiss-mcp/src/data/meteoswiss-search-data.ts
+++ b/packages/meteoswiss-mcp/src/data/meteoswiss-search-data.ts
@@ -4,7 +4,13 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { fetchJson, HttpRequestError } from '../support/http-communication.js';
 import { debugData } from '../support/logging.js';
-import type { SearchMeteoSwissContentInput } from '../schemas/meteoswiss-search.js';
+import type {
+  SearchMeteoSwissContentInput,
+  SearchResultItem,
+  SearchResults,
+} from '../schemas/meteoswiss-search.js';
+
+export type { SearchResultItem, SearchResults } from '../schemas/meteoswiss-search.js';
 
 // Solr response types
 interface SolrDocument {
@@ -55,31 +61,6 @@ const USE_TEST_FIXTURES = process.env.USE_TEST_FIXTURES === 'true';
  * doesn't honor — see GitHub issue #110, DECISION-1.
  */
 const UPSTREAM_PAGE_SIZE = 10;
-
-/**
- * Search result item from the API
- */
-export interface SearchResultItem {
-  id: string;
-  title: string;
-  url: string;
-  description?: string;
-  contentType?: string;
-  lastModified?: string;
-  path?: string;
-  lead?: string;
-  publicationDate?: string;
-}
-
-/**
- * Search results response
- */
-export interface SearchResults {
-  totalResults: number;
-  page: number;
-  pageSize: number;
-  results: SearchResultItem[];
-}
 
 /**
  * Search MeteoSwiss content

--- a/packages/meteoswiss-mcp/src/schemas/meteoswiss-fetch.ts
+++ b/packages/meteoswiss-mcp/src/schemas/meteoswiss-fetch.ts
@@ -32,3 +32,28 @@ export const fetchMeteoSwissContentSchema = z.object({
 });
 
 export type FetchMeteoSwissContentInput = z.infer<typeof fetchMeteoSwissContentSchema>;
+
+/** Fetched page content response (field names match the ChatGPT Deep Research MCP contract) */
+export const ContentResponseSchema = z.object({
+  id: z.string().describe('The id the content was fetched for (the page URL)'),
+  title: z.string().optional().describe('Page title'),
+  text: z.string().describe('Canonical body field (matches ChatGPT Deep Research spec)'),
+  format: z.enum(['markdown', 'text']).describe('Format of `text`'),
+  url: z
+    .string()
+    .describe(
+      'Canonical URL field (matches ChatGPT Deep Research spec). For this server `url === id`.'
+    ),
+  metadata: z
+    .object({
+      url: z.string(),
+      language: z.string().optional(),
+      lastModified: z.string().optional(),
+      contentType: z.string().optional(),
+      keywords: z.array(z.string()).optional(),
+      description: z.string().optional(),
+    })
+    .optional()
+    .describe('Page metadata (present when includeMetadata is true)'),
+});
+export type ContentResponse = z.infer<typeof ContentResponseSchema>;

--- a/packages/meteoswiss-mcp/src/schemas/meteoswiss-search.ts
+++ b/packages/meteoswiss-mcp/src/schemas/meteoswiss-search.ts
@@ -46,3 +46,30 @@ export const searchMeteoSwissContentSchema = z.object({
 });
 
 export type SearchMeteoSwissContentInput = z.infer<typeof searchMeteoSwissContentSchema>;
+
+/** A single search result item */
+export const SearchResultItemSchema = z.object({
+  id: z.string().describe('Result identifier — the page URL (pass to the fetch tool)'),
+  title: z.string().describe('Page title'),
+  url: z.string().describe('Full page URL'),
+  description: z.string().optional().describe('Short description of the page'),
+  contentType: z.string().optional().describe('Content type of the result'),
+  lastModified: z.string().optional().describe('Last modification date'),
+  path: z.string().optional().describe('Site path of the page'),
+  lead: z.string().optional().describe('Lead/teaser text'),
+  publicationDate: z.string().optional().describe('Publication date'),
+});
+export type SearchResultItem = z.infer<typeof SearchResultItemSchema>;
+
+/** Search results response */
+export const SearchResultsSchema = z.object({
+  totalResults: z.number().describe('Total number of matches across all pages'),
+  page: z.number().describe('Current page number (1-based)'),
+  pageSize: z
+    .number()
+    .describe(
+      'Number of items in `results` for this page — at most 10 (the upstream API pages by a fixed 10), fewer on the last page'
+    ),
+  results: z.array(SearchResultItemSchema).describe('Result items for this page'),
+});
+export type SearchResults = z.infer<typeof SearchResultsSchema>;

--- a/packages/meteoswiss-mcp/src/schemas/ogd-climate-data.ts
+++ b/packages/meteoswiss-mcp/src/schemas/ogd-climate-data.ts
@@ -48,42 +48,63 @@ export const GetClimateDataParamsSchema = z.object({
 export type GetClimateDataParams = z.infer<typeof GetClimateDataParamsSchema>;
 
 /** A single climate measurement row */
-export type ClimateMeasurement = {
-  date: string;
-  temperature_mean?: number;
-  temperature_max?: number;
-  temperature_min?: number;
-  precipitation?: number;
-  sunshine_duration_min?: number;
-  radiation_w_m2?: number;
-  wind_speed_m_s?: number;
-  pressure_hpa?: number;
-  frost_days?: number;
-  summer_days?: number;
-  heat_days?: number;
-  ice_days?: number;
-  tropical_nights?: number;
-  rain_days?: number;
-};
+export const ClimateMeasurementSchema = z.object({
+  date: z
+    .string()
+    .describe('Measurement date (YYYY-MM-DD; first day of period for monthly/yearly)'),
+  temperature_mean: z.number().optional().describe('Mean temperature, °C'),
+  temperature_max: z.number().optional().describe('Maximum temperature, °C'),
+  temperature_min: z.number().optional().describe('Minimum temperature, °C'),
+  precipitation: z.number().optional().describe('Precipitation total, mm'),
+  sunshine_duration_min: z.number().optional().describe('Sunshine duration, minutes'),
+  radiation_w_m2: z.number().optional().describe('Global radiation, W/m²'),
+  wind_speed_m_s: z.number().optional().describe('Wind speed, m/s'),
+  pressure_hpa: z.number().optional().describe('Air pressure, hPa'),
+  frost_days: z.number().optional().describe('Days with minimum below 0 °C (monthly/yearly)'),
+  summer_days: z
+    .number()
+    .optional()
+    .describe('Days with maximum of 25 °C or above (monthly/yearly)'),
+  heat_days: z.number().optional().describe('Days with maximum of 30 °C or above (monthly/yearly)'),
+  ice_days: z.number().optional().describe('Days with maximum below 0 °C (monthly/yearly)'),
+  tropical_nights: z
+    .number()
+    .optional()
+    .describe('Nights with minimum of 20 °C or above (monthly/yearly)'),
+  rain_days: z.number().optional().describe('Days with measurable precipitation (monthly/yearly)'),
+});
+export type ClimateMeasurement = z.infer<typeof ClimateMeasurementSchema>;
 
 /** Climate data response */
-export type ClimateDataResponse = {
-  station: {
-    name: string;
-    abbreviation: string;
-    elevation: number;
-    coordinates: { lat: number; lon: number };
-    canton?: string;
-    distance_km?: number;
-    network: string;
-  };
-  resolution: ClimateResolution;
-  data: ClimateMeasurement[];
-  /**
-   * Present only when `data` is empty because the requested date range fell
-   * outside the fetched series (e.g. a daily request older than the ~2-year
-   * `_recent` window). Explains why and suggests a fallback resolution.
-   */
-  note?: string;
-  source: string;
-};
+export const ClimateDataResponseSchema = z.object({
+  station: z.object({
+    name: z.string().describe('Climate station name'),
+    abbreviation: z.string().describe('Official station abbreviation (e.g. "SMA")'),
+    elevation: z.number().describe('Elevation in metres above sea level'),
+    coordinates: CoordinatesSchema.describe('WGS84 coordinates of the station'),
+    canton: z.string().optional().describe('Canton abbreviation (e.g. "ZH")'),
+    distance_km: z
+      .number()
+      .optional()
+      .describe(
+        'Distance from the queried location to this station, km (when resolved by proximity)'
+      ),
+    network: z
+      .string()
+      .describe(
+        'NBCN network kind ("climate" full climate series, "precipitation" precipitation-only)'
+      ),
+  }),
+  resolution: z.enum(CLIMATE_RESOLUTIONS).describe('Resolution the returned rows are in'),
+  data: z
+    .array(ClimateMeasurementSchema)
+    .describe('Measurement rows, filtered and limited as requested'),
+  note: z
+    .string()
+    .optional()
+    .describe(
+      'Present only when `data` is empty because the requested date range fell outside the fetched series (e.g. a daily request older than the ~2-year `_recent` window). Explains why and suggests a fallback resolution.'
+    ),
+  source: z.string().describe('Data attribution'),
+});
+export type ClimateDataResponse = z.infer<typeof ClimateDataResponseSchema>;

--- a/packages/meteoswiss-mcp/src/schemas/ogd-current-weather.ts
+++ b/packages/meteoswiss-mcp/src/schemas/ogd-current-weather.ts
@@ -24,50 +24,66 @@ export const GetCurrentWeatherParamsSchema = z.object({
 export type GetCurrentWeatherParams = z.infer<typeof GetCurrentWeatherParamsSchema>;
 
 /** Measurement value with unit (only present when data is available) */
-export type MeasurementValue = {
-  value: number;
-  unit: string;
-};
+export const MeasurementValueSchema = z.object({
+  value: z.number(),
+  unit: z.string(),
+});
+export type MeasurementValue = z.infer<typeof MeasurementValueSchema>;
 
 /** Current weather response */
-export type CurrentWeatherResponse = {
-  station: {
-    name: string;
-    abbreviation: string;
-    elevation: number;
-    coordinates: { lat: number; lon: number };
-    municipality?: string;
-    canton?: string;
-    distance_km?: number;
-    network?: string;
-  };
-  timestamp: string;
-  measurements: {
-    temperature?: MeasurementValue;
-    humidity?: MeasurementValue;
-    dew_point?: MeasurementValue;
-    precipitation?: MeasurementValue;
-    wind_speed?: MeasurementValue;
-    wind_gust?: MeasurementValue;
-    wind_direction?: MeasurementValue;
-    sunshine?: MeasurementValue;
-    radiation?: MeasurementValue;
-    pressure_station?: MeasurementValue;
-    pressure_sea_level?: MeasurementValue;
-    snow_depth?: MeasurementValue;
-  };
-  /** Visual observations (only for 8 OBS stations: ALT, BAS, CHU, GSB, JUN, SAE, SIO, SMA) */
-  visual_observations?: {
-    date: string;
-    cloud_cover_percent?: number;
-    is_clear_day?: boolean;
-    is_overcast_day?: boolean;
-    has_rain?: boolean;
-    has_rain_and_snow?: boolean;
-    has_snowfall?: boolean;
-    has_hail?: boolean;
-    has_fog?: boolean;
-    has_snow_coverage?: boolean;
-  };
-  source: string;
-};
+export const CurrentWeatherResponseSchema = z.object({
+  station: z.object({
+    name: z.string().describe('Station name'),
+    abbreviation: z.string().describe('Official station abbreviation (e.g. "SMA")'),
+    elevation: z.number().describe('Elevation in metres above sea level'),
+    coordinates: CoordinatesSchema.describe('WGS84 coordinates of the station'),
+    municipality: z.string().optional(),
+    canton: z.string().optional().describe('Canton abbreviation (e.g. "ZH")'),
+    distance_km: z
+      .number()
+      .optional()
+      .describe(
+        'Distance from the queried location to this station, km (when resolved by proximity)'
+      ),
+    network: z
+      .string()
+      .optional()
+      .describe('Measurement network ("smn" full weather, "smn-precip" precipitation-only)'),
+  }),
+  timestamp: z.string().describe('Measurement timestamp (ISO 8601)'),
+  measurements: z
+    .object({
+      temperature: MeasurementValueSchema.optional(),
+      humidity: MeasurementValueSchema.optional(),
+      dew_point: MeasurementValueSchema.optional(),
+      precipitation: MeasurementValueSchema.optional(),
+      wind_speed: MeasurementValueSchema.optional(),
+      wind_gust: MeasurementValueSchema.optional(),
+      wind_direction: MeasurementValueSchema.optional(),
+      sunshine: MeasurementValueSchema.optional(),
+      radiation: MeasurementValueSchema.optional(),
+      pressure_station: MeasurementValueSchema.optional(),
+      pressure_sea_level: MeasurementValueSchema.optional(),
+      snow_depth: MeasurementValueSchema.optional(),
+    })
+    .describe('Each measurement is present only when the station reports it'),
+  visual_observations: z
+    .object({
+      date: z.string(),
+      cloud_cover_percent: z.number().optional(),
+      is_clear_day: z.boolean().optional(),
+      is_overcast_day: z.boolean().optional(),
+      has_rain: z.boolean().optional(),
+      has_rain_and_snow: z.boolean().optional(),
+      has_snowfall: z.boolean().optional(),
+      has_hail: z.boolean().optional(),
+      has_fog: z.boolean().optional(),
+      has_snow_coverage: z.boolean().optional(),
+    })
+    .optional()
+    .describe(
+      'Visual observations (only for 8 OBS stations: ALT, BAS, CHU, GSB, JUN, SAE, SIO, SMA)'
+    ),
+  source: z.string().describe('Data attribution'),
+});
+export type CurrentWeatherResponse = z.infer<typeof CurrentWeatherResponseSchema>;

--- a/packages/meteoswiss-mcp/src/schemas/ogd-local-forecast.ts
+++ b/packages/meteoswiss-mcp/src/schemas/ogd-local-forecast.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from 'zod';
+import { CoordinatesSchema } from './ogd-shared.js';
 
 export const GetLocalForecastParamsSchema = z.object({
   location: z
@@ -31,68 +32,87 @@ export type GetLocalForecastParams = z.infer<typeof GetLocalForecastParamsSchema
  * Each field is independently nullable — an hour is included whenever at least one series has
  * a reading for it, even if others are missing for that specific hour.
  */
-export type HourlyEntry = {
-  /** ISO 8601 timestamp with UTC offset, in local Europe/Zurich time (e.g. "2026-03-28T09:00:00+01:00") */
-  time: string;
-  /** Temperature at this hour, in °C */
-  temperature_c: number | null;
-  /** Precipitation sum for this hour, in mm */
-  precip_mm: number | null;
-  /** Sunshine duration within this hour, in minutes */
-  sunshine_minutes: number | null;
-  /** Mean wind speed for this hour, in km/h */
-  wind_kmh: number | null;
-  /** Peak wind gust for this hour, in km/h */
-  wind_gust_kmh: number | null;
-};
+export const HourlyEntrySchema = z.object({
+  time: z
+    .string()
+    .describe(
+      'ISO 8601 timestamp with UTC offset, in local Europe/Zurich time (e.g. "2026-03-28T09:00:00+01:00")'
+    ),
+  temperature_c: z.number().nullable().describe('Temperature at this hour, in °C'),
+  precip_mm: z.number().nullable().describe('Precipitation sum for this hour, in mm'),
+  sunshine_minutes: z
+    .number()
+    .nullable()
+    .describe('Sunshine duration within this hour, in minutes'),
+  wind_kmh: z.number().nullable().describe('Mean wind speed for this hour, in km/h'),
+  wind_gust_kmh: z.number().nullable().describe('Peak wind gust for this hour, in km/h'),
+});
+export type HourlyEntry = z.infer<typeof HourlyEntrySchema>;
 
 /** Daily forecast summary for one day */
-export type DailyForecast = {
-  /** Local Europe/Zurich calendar date (YYYY-MM-DD) for postal codes/mountain points; the station data source's native daily date for weather stations. */
-  date: string;
-  weather: string | null;
-  weather_icon_url: string | null;
-  /**
-   * Daily temperature min/max, °C. For postal codes/mountain points, derived from the same
-   * hourly series as `hourly` (so they cannot disagree). For weather stations, MeteoSwiss's
-   * official daily aggregate (`tre200dn`/`tre200dx`) — may capture sub-hourly extremes the
-   * hourly series alone wouldn't show.
-   */
-  temperature_min_c: number | null;
-  temperature_max_c: number | null;
-  /**
-   * Daily precipitation total, mm. For postal codes/mountain points, the sum of `hourly`'s
-   * `precip_mm` (cannot disagree with the series). For weather stations, MeteoSwiss's official
-   * daily aggregate (`rka150d0`) — a *different* product than re-summing the station's hourly
-   * series, so it may legitimately NOT equal `sum(hourly precip_mm)` for stations. This is
-   * expected, not a data inconsistency.
-   */
-  precipitation_total_mm: number | null;
-  /** Daily sunshine total, minutes. Derived from `hourly`'s `sunshine_minutes` for every point type (no official daily aggregate exists for this parameter). */
-  sunshine_total_minutes: number | null;
-  /** Daily mean wind speed, km/h. Derived from `hourly`'s `wind_kmh` for every point type. */
-  wind_avg_kmh: number | null;
-  /** Daily peak wind gust, km/h. Derived from `hourly`'s `wind_gust_kmh` for every point type. */
-  wind_gust_max_kmh: number | null;
-  /**
-   * Per-hour breakdown across every series, keyed to the local Europe/Zurich calendar day this
-   * `date` represents (each entry's `time` always falls within this day). `null` when no hourly
-   * breakdown exists for this location at all (a total data gap); `[]` when the point type
-   * supports hourly data but none was available for this specific day. A dry/calm/sunless hour
-   * still appears with its measured 0 value — 0-valued readings are kept, not omitted.
-   */
-  hourly: HourlyEntry[] | null;
-};
+export const DailyForecastSchema = z.object({
+  date: z
+    .string()
+    .describe(
+      "Local Europe/Zurich calendar date (YYYY-MM-DD) for postal codes/mountain points; the station data source's native daily date for weather stations."
+    ),
+  weather: z.string().nullable().describe('Human-readable weather description'),
+  weather_icon_url: z.string().nullable().describe('URL of the official MeteoSwiss weather icon'),
+  temperature_min_c: z
+    .number()
+    .nullable()
+    .describe(
+      "Daily temperature minimum, °C. For postal codes/mountain points, derived from the same hourly series as `hourly` (so they cannot disagree). For weather stations, MeteoSwiss's official daily aggregate (`tre200dn`) — may capture sub-hourly extremes the hourly series alone wouldn't show."
+    ),
+  temperature_max_c: z
+    .number()
+    .nullable()
+    .describe(
+      'Daily temperature maximum, °C. Same sourcing rules as temperature_min_c (station aggregate: `tre200dx`).'
+    ),
+  precipitation_total_mm: z
+    .number()
+    .nullable()
+    .describe(
+      "Daily precipitation total, mm. For postal codes/mountain points, the sum of `hourly`'s `precip_mm` (cannot disagree with the series). For weather stations, MeteoSwiss's official daily aggregate (`rka150d0`) — a *different* product than re-summing the station's hourly series, so it may legitimately NOT equal `sum(hourly precip_mm)` for stations. This is expected, not a data inconsistency."
+    ),
+  sunshine_total_minutes: z
+    .number()
+    .nullable()
+    .describe(
+      "Daily sunshine total, minutes. Derived from `hourly`'s `sunshine_minutes` for every point type (no official daily aggregate exists for this parameter)."
+    ),
+  wind_avg_kmh: z
+    .number()
+    .nullable()
+    .describe(
+      "Daily mean wind speed, km/h. Derived from `hourly`'s `wind_kmh` for every point type."
+    ),
+  wind_gust_max_kmh: z
+    .number()
+    .nullable()
+    .describe(
+      "Daily peak wind gust, km/h. Derived from `hourly`'s `wind_gust_kmh` for every point type."
+    ),
+  hourly: z
+    .array(HourlyEntrySchema)
+    .nullable()
+    .describe(
+      "Per-hour breakdown across every series, keyed to the local Europe/Zurich calendar day this `date` represents (each entry's `time` always falls within this day). `null` when no hourly breakdown exists for this location at all (a total data gap); `[]` when the point type supports hourly data but none was available for this specific day. A dry/calm/sunless hour still appears with its measured 0 value — 0-valued readings are kept, not omitted."
+    ),
+});
+export type DailyForecast = z.infer<typeof DailyForecastSchema>;
 
 /** Full forecast response */
-export type LocalForecastResponse = {
-  location: {
-    name: string;
-    type: string;
-    elevation: number;
-    coordinates: { lat: number; lon: number };
-  };
-  generated: string;
-  forecast: DailyForecast[];
-  source: string;
-};
+export const LocalForecastResponseSchema = z.object({
+  location: z.object({
+    name: z.string().describe('Resolved location name'),
+    type: z.string().describe('Point type: "station", "postal_code", or "mountain"'),
+    elevation: z.number().describe('Elevation in metres above sea level'),
+    coordinates: CoordinatesSchema.describe('WGS84 coordinates of the resolved point'),
+  }),
+  generated: z.string().describe('Timestamp the forecast was generated (ISO 8601)'),
+  forecast: z.array(DailyForecastSchema).describe('One entry per forecast day, in date order'),
+  source: z.string().describe('Data attribution'),
+});
+export type LocalForecastResponse = z.infer<typeof LocalForecastResponseSchema>;

--- a/packages/meteoswiss-mcp/src/schemas/ogd-pollen-data.ts
+++ b/packages/meteoswiss-mcp/src/schemas/ogd-pollen-data.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from 'zod';
+import { CoordinatesSchema } from './ogd-shared.js';
 
 export const GetPollenDataParamsSchema = z.object({
   station: z
@@ -20,23 +21,39 @@ export type GetPollenDataParams = z.infer<typeof GetPollenDataParamsSchema>;
  * absent reading explicit (e.g. out of season) instead of silently omitting
  * the type (issue #110, DECISION-3).
  */
-export type PollenMeasurement =
-  | { type: string; status: 'measured'; value: number; unit: string }
-  | { type: string; status: 'no-current-data' };
+export const PollenMeasurementSchema = z.discriminatedUnion('status', [
+  z.object({
+    type: z.string().describe('Pollen species (e.g. "birch", "grasses")'),
+    status: z.literal('measured'),
+    value: z.number().describe('Concentration reading'),
+    unit: z.string().describe('Concentration unit (particles/m³)'),
+  }),
+  z.object({
+    type: z.string().describe('Pollen species (e.g. "birch", "grasses")'),
+    status: z
+      .literal('no-current-data')
+      .describe('No current reading for this species (e.g. out of season) — explicit, not omitted'),
+  }),
+]);
+export type PollenMeasurement = z.infer<typeof PollenMeasurementSchema>;
 
 /** Pollen data for one station */
-export type StationPollenData = {
-  station: {
-    name: string;
-    abbreviation: string;
-    coordinates: { lat: number; lon: number };
-  };
-  timestamp: string;
-  pollen: PollenMeasurement[];
-};
+export const StationPollenDataSchema = z.object({
+  station: z.object({
+    name: z.string().describe('Pollen station name'),
+    abbreviation: z.string().describe('Pollen station abbreviation (e.g. "PZH")'),
+    coordinates: CoordinatesSchema.describe('WGS84 coordinates of the station'),
+  }),
+  timestamp: z.string().describe('Measurement timestamp (ISO 8601)'),
+  pollen: z
+    .array(PollenMeasurementSchema)
+    .describe('One entry per measured species — every known species always appears'),
+});
+export type StationPollenData = z.infer<typeof StationPollenDataSchema>;
 
 /** Pollen data response */
-export type PollenDataResponse = {
-  stations: StationPollenData[];
-  source: string;
-};
+export const PollenDataResponseSchema = z.object({
+  stations: z.array(StationPollenDataSchema).describe('One entry per pollen station'),
+  source: z.string().describe('Data attribution'),
+});
+export type PollenDataResponse = z.infer<typeof PollenDataResponseSchema>;

--- a/packages/meteoswiss-mcp/src/schemas/ogd-station-list.ts
+++ b/packages/meteoswiss-mcp/src/schemas/ogd-station-list.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from 'zod';
+import { CoordinatesSchema } from './ogd-shared.js';
 
 export const ListStationsParamsSchema = z.object({
   search: z.string().optional().describe('Search by station name or abbreviation'),
@@ -23,18 +24,20 @@ export const ListStationsParamsSchema = z.object({
 export type ListStationsParams = z.infer<typeof ListStationsParamsSchema>;
 
 /** Station entry in the list */
-export type StationListEntry = {
-  abbreviation: string;
-  name: string;
-  canton: string;
-  elevation: number;
-  coordinates: { lat: number; lon: number };
-  data_since: string;
-};
+export const StationListEntrySchema = z.object({
+  abbreviation: z.string().describe('Official station abbreviation (e.g. "SMA")'),
+  name: z.string().describe('Station name'),
+  canton: z.string().describe('Canton abbreviation (e.g. "ZH")'),
+  elevation: z.number().describe('Elevation in metres above sea level'),
+  coordinates: CoordinatesSchema.describe('WGS84 coordinates of the station'),
+  data_since: z.string().describe('Date the station started reporting data'),
+});
+export type StationListEntry = z.infer<typeof StationListEntrySchema>;
 
 /** Station list response */
-export type StationListResponse = {
-  total: number;
-  stations: StationListEntry[];
-  source: string;
-};
+export const StationListResponseSchema = z.object({
+  total: z.number().describe('Total number of stations matching the filter'),
+  stations: z.array(StationListEntrySchema).describe('Matching stations, up to `limit`'),
+  source: z.string().describe('Data attribution'),
+});
+export type StationListResponse = z.infer<typeof StationListResponseSchema>;

--- a/packages/meteoswiss-mcp/src/server.ts
+++ b/packages/meteoswiss-mcp/src/server.ts
@@ -4,25 +4,34 @@
  */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { searchMeteoSwissContentSchema } from './schemas/meteoswiss-search.js';
+import { searchMeteoSwissContentSchema, SearchResultsSchema } from './schemas/meteoswiss-search.js';
 import type { SearchMeteoSwissContentInput } from './schemas/meteoswiss-search.js';
-import { fetchMeteoSwissContentSchema } from './schemas/meteoswiss-fetch.js';
+import { fetchMeteoSwissContentSchema, ContentResponseSchema } from './schemas/meteoswiss-fetch.js';
 import type { FetchMeteoSwissContentInput } from './schemas/meteoswiss-fetch.js';
 import { meteoswissSearchTool } from './tools/meteoswiss-search.js';
 import { meteoswissFetchTool } from './tools/meteoswiss-fetch.js';
-import { GetLocalForecastParamsSchema } from './schemas/ogd-local-forecast.js';
+import {
+  GetLocalForecastParamsSchema,
+  LocalForecastResponseSchema,
+} from './schemas/ogd-local-forecast.js';
 import type { GetLocalForecastParams } from './schemas/ogd-local-forecast.js';
 import { getLocalForecast } from './data/ogd-local-forecast.js';
-import { GetCurrentWeatherParamsSchema } from './schemas/ogd-current-weather.js';
+import {
+  GetCurrentWeatherParamsSchema,
+  CurrentWeatherResponseSchema,
+} from './schemas/ogd-current-weather.js';
 import type { GetCurrentWeatherParams } from './schemas/ogd-current-weather.js';
 import { getCurrentWeather } from './data/ogd-current-weather.js';
-import { ListStationsParamsSchema } from './schemas/ogd-station-list.js';
+import { ListStationsParamsSchema, StationListResponseSchema } from './schemas/ogd-station-list.js';
 import type { ListStationsParams } from './schemas/ogd-station-list.js';
 import { listStations } from './data/ogd-station-list.js';
-import { GetPollenDataParamsSchema } from './schemas/ogd-pollen-data.js';
+import { GetPollenDataParamsSchema, PollenDataResponseSchema } from './schemas/ogd-pollen-data.js';
 import type { GetPollenDataParams } from './schemas/ogd-pollen-data.js';
 import { getPollenData } from './data/ogd-pollen-data.js';
-import { GetClimateDataParamsSchema } from './schemas/ogd-climate-data.js';
+import {
+  GetClimateDataParamsSchema,
+  ClimateDataResponseSchema,
+} from './schemas/ogd-climate-data.js';
 import type { GetClimateDataParams } from './schemas/ogd-climate-data.js';
 import { getClimateData } from './data/ogd-climate-data.js';
 import { debugServer, debugTools } from './support/logging.js';
@@ -60,10 +69,14 @@ export function createServer(): McpServer {
 
   // Register search tool
   debugServer('Registering tool: search');
-  server.tool(
+  server.registerTool(
     'search',
-    'Search MeteoSwiss website content in multiple languages (DE, FR, IT, EN). Returns relevant pages with URLs that can be passed to the fetch tool. Always returns up to 10 results per page — the upstream API has a fixed page size that cannot be changed. Note: pagination may return duplicate results across pages (upstream API limitation).',
-    searchMeteoSwissContentSchema.shape,
+    {
+      description:
+        'Search MeteoSwiss website content in multiple languages (DE, FR, IT, EN). Returns relevant pages with URLs that can be passed to the fetch tool. Always returns up to 10 results per page — the upstream API has a fixed page size that cannot be changed. Note: pagination may return duplicate results across pages (upstream API limitation).',
+      inputSchema: searchMeteoSwissContentSchema.shape,
+      outputSchema: SearchResultsSchema.shape,
+    },
     async (params: SearchMeteoSwissContentInput) => {
       const _t0 = performance.now();
       try {
@@ -82,6 +95,7 @@ export function createServer(): McpServer {
               text: JSON.stringify(results, null, 2),
             },
           ],
+          structuredContent: results,
         };
       } catch (error: unknown) {
         console.error('Error in search tool:', error);
@@ -103,10 +117,14 @@ export function createServer(): McpServer {
 
   // Register fetch tool with ChatGPT-compatible name
   debugServer('Registering tool: fetch');
-  server.tool(
+  server.registerTool(
     'fetch',
-    'Fetch full content from a MeteoSwiss webpage and convert to markdown or plain text. Use the search tool first to discover valid page URLs, then pass the full URL as the id parameter.',
-    fetchMeteoSwissContentSchema.shape,
+    {
+      description:
+        'Fetch full content from a MeteoSwiss webpage and convert to markdown or plain text. Use the search tool first to discover valid page URLs, then pass the full URL as the id parameter.',
+      inputSchema: fetchMeteoSwissContentSchema.shape,
+      outputSchema: ContentResponseSchema.shape,
+    },
     async (params: FetchMeteoSwissContentInput) => {
       const _t0 = performance.now();
       try {
@@ -125,6 +143,7 @@ export function createServer(): McpServer {
               text: JSON.stringify(content, null, 2),
             },
           ],
+          structuredContent: content,
         };
       } catch (error: unknown) {
         console.error('Error in fetch tool:', error);
@@ -146,9 +165,10 @@ export function createServer(): McpServer {
 
   // Register getLocalForecast tool (OGD)
   debugServer('Registering tool: getLocalForecast');
-  server.tool(
+  server.registerTool(
     'meteoswissLocalForecast',
-    `Get a multi-day weather forecast for any Swiss location. Returns daily summaries (temperature, precipitation, sunshine, wind, weather icon) plus a hierarchical hourly breakdown of every series.
+    {
+      description: `Get a multi-day weather forecast for any Swiss location. Returns daily summaries (temperature, precipitation, sunshine, wind, weather icon) plus a hierarchical hourly breakdown of every series.
 
 This uses official MeteoSwiss Open Data — the same forecasts powering the MeteoSwiss app and website.
 
@@ -185,7 +205,9 @@ useful for judging *when* rain, sun, or wind is expected, not just the daily sum
   stations and are always derived from the hourly series. For postal codes/mountain
   points, every summary field is derived from the same hourly series shown alongside it,
   so it always matches summing/averaging that series exactly.`,
-    GetLocalForecastParamsSchema.shape,
+      inputSchema: GetLocalForecastParamsSchema.shape,
+      outputSchema: LocalForecastResponseSchema.shape,
+    },
     async (params: GetLocalForecastParams) => {
       const _t0 = performance.now();
       try {
@@ -204,6 +226,7 @@ useful for judging *when* rain, sun, or wind is expected, not just the daily sum
               text: JSON.stringify(result, null, 2),
             },
           ],
+          structuredContent: result,
         };
       } catch (error: unknown) {
         console.error('Error in getLocalForecast tool:', error);
@@ -225,14 +248,17 @@ useful for judging *when* rain, sun, or wind is expected, not just the daily sum
 
   // Register getCurrentWeather tool (OGD)
   debugServer('Registering tool: getCurrentWeather');
-  server.tool(
+  server.registerTool(
     'meteoswissCurrentWeather',
-    `Get real-time weather measurements from ~300 Swiss automatic weather stations (~160 full weather + ~140 precipitation-only). Returns temperature, precipitation, wind, humidity, pressure, sunshine, and more. Data updates every 10 minutes. Precipitation-only stations return only rainfall data.
+    {
+      description: `Get real-time weather measurements from ~300 Swiss automatic weather stations (~160 full weather + ~140 precipitation-only). Returns temperature, precipitation, wind, humidity, pressure, sunshine, and more. Data updates every 10 minutes. Precipitation-only stations return only rainfall data.
 
 For 8 stations (Zurich, Basel, Chur, Sion, Altdorf, Säntis, Jungfraujoch, Grand St-Bernard), also includes daily visual observations: cloud cover, fog, rain, snowfall, hail, and snow coverage.
 
 Accepts station names ("Zurich"), abbreviations ("SMA"), addresses ("Bahnhofplatz 1 Bern"), or WGS84 coordinates. Automatically finds the nearest station.`,
-    GetCurrentWeatherParamsSchema.shape,
+      inputSchema: GetCurrentWeatherParamsSchema.shape,
+      outputSchema: CurrentWeatherResponseSchema.shape,
+    },
     async (params: GetCurrentWeatherParams) => {
       const _t0 = performance.now();
       try {
@@ -243,7 +269,10 @@ Accepts station names ("Zurich"), abbreviations ("SMA"), addresses ("Bahnhofplat
         const result = await getCurrentWeather(params);
         console.error('Successfully retrieved current weather');
         recordToolCall('meteoswissCurrentWeather', performance.now() - _t0);
-        return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        };
       } catch (error: unknown) {
         console.error('Error in meteoswissCurrentWeather tool:', error);
         debugTools('Error in getCurrentWeather: %O', error);
@@ -263,10 +292,13 @@ Accepts station names ("Zurich"), abbreviations ("SMA"), addresses ("Bahnhofplat
 
   // Register listStations tool (OGD)
   debugServer('Registering tool: listStations');
-  server.tool(
+  server.registerTool(
     'meteoswissStations',
-    `List and search MeteoSwiss automatic weather stations. Filter by name, canton, or browse the full network of ~160 stations across Switzerland.`,
-    ListStationsParamsSchema.shape,
+    {
+      description: `List and search MeteoSwiss automatic weather stations. Filter by name, canton, or browse the full network of ~160 stations across Switzerland.`,
+      inputSchema: ListStationsParamsSchema.shape,
+      outputSchema: StationListResponseSchema.shape,
+    },
     async (params: ListStationsParams) => {
       const _t0 = performance.now();
       try {
@@ -277,7 +309,10 @@ Accepts station names ("Zurich"), abbreviations ("SMA"), addresses ("Bahnhofplat
         const result = await listStations(params);
         console.error(`Successfully listed ${result.total} stations`);
         recordToolCall('meteoswissStations', performance.now() - _t0);
-        return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        };
       } catch (error: unknown) {
         console.error('Error in meteoswissStations tool:', error);
         debugTools('Error in listStations: %O', error);
@@ -297,10 +332,13 @@ Accepts station names ("Zurich"), abbreviations ("SMA"), addresses ("Bahnhofplat
 
   // Register getPollenData tool (OGD)
   debugServer('Registering tool: getPollenData');
-  server.tool(
+  server.registerTool(
     'meteoswissPollenData',
-    `Get current pollen concentration data from MeteoSwiss monitoring stations (~15 stations across Switzerland). Shows pollen levels for 7 measured species (alder, birch, hazel, beech, ash, oak, grasses) — each is always included, with a "no-current-data" status when out of season. Ambrosia (ragweed) is a MeteoSwiss forecast-only category and is not part of this OGD measurement network, so it is not included. Useful for allergy sufferers.`,
-    GetPollenDataParamsSchema.shape,
+    {
+      description: `Get current pollen concentration data from MeteoSwiss monitoring stations (~15 stations across Switzerland). Shows pollen levels for 7 measured species (alder, birch, hazel, beech, ash, oak, grasses) — each is always included, with a "no-current-data" status when out of season. Ambrosia (ragweed) is a MeteoSwiss forecast-only category and is not part of this OGD measurement network, so it is not included. Useful for allergy sufferers.`,
+      inputSchema: GetPollenDataParamsSchema.shape,
+      outputSchema: PollenDataResponseSchema.shape,
+    },
     async (params: GetPollenDataParams) => {
       const _t0 = performance.now();
       try {
@@ -311,7 +349,10 @@ Accepts station names ("Zurich"), abbreviations ("SMA"), addresses ("Bahnhofplat
         const result = await getPollenData(params);
         console.error(`Successfully retrieved pollen data for ${result.stations.length} stations`);
         recordToolCall('meteoswissPollenData', performance.now() - _t0);
-        return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        };
       } catch (error: unknown) {
         console.error('Error in meteoswissPollenData tool:', error);
         debugTools('Error in getPollenData: %O', error);
@@ -331,16 +372,19 @@ Accepts station names ("Zurich"), abbreviations ("SMA"), addresses ("Bahnhofplat
 
   // Register getClimateData tool (OGD NBCN)
   debugServer('Registering tool: getClimateData');
-  server.tool(
+  server.registerTool(
     'meteoswissClimateData',
-    `Get homogeneous climate measurement series from Switzerland's National Basic Climatic Network (NBCN). Returns temperature, precipitation, sunshine, radiation, wind, pressure, and climate indicators (frost days, summer days, heat days) going back decades.
+    {
+      description: `Get homogeneous climate measurement series from Switzerland's National Basic Climatic Network (NBCN). Returns temperature, precipitation, sunshine, radiation, wind, pressure, and climate indicators (frost days, summer days, heat days) going back decades.
 
 29 climate stations + 46 precipitation stations with daily, monthly, and yearly resolution.
 
 Use cases: "What are typical January temperatures in Zurich?", "How has precipitation changed in Basel over 50 years?", "How many heat days did Lugano have last year?"
 
 Accepts station names ("Zurich", "Basel"), abbreviations ("SMA", "BAS"), or WGS84 coordinates.`,
-    GetClimateDataParamsSchema.shape,
+      inputSchema: GetClimateDataParamsSchema.shape,
+      outputSchema: ClimateDataResponseSchema.shape,
+    },
     async (params: GetClimateDataParams) => {
       const _t0 = performance.now();
       try {
@@ -351,7 +395,10 @@ Accepts station names ("Zurich", "Basel"), abbreviations ("SMA", "BAS"), or WGS8
         const result = await getClimateData(params);
         console.error(`Successfully retrieved climate data: ${result.data.length} rows`);
         recordToolCall('meteoswissClimateData', performance.now() - _t0);
-        return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        };
       } catch (error: unknown) {
         console.error('Error in meteoswissClimateData tool:', error);
         debugTools('Error in getClimateData: %O', error);

--- a/packages/meteoswiss-mcp/src/tools/meteoswiss-fetch.ts
+++ b/packages/meteoswiss-mcp/src/tools/meteoswiss-fetch.ts
@@ -1,4 +1,4 @@
-import { fetchMeteoSwissContentSchema } from '../schemas/meteoswiss-fetch.js';
+import { fetchMeteoSwissContentSchema, type ContentResponse } from '../schemas/meteoswiss-fetch.js';
 import { fetchMeteoSwissContent } from '../data/meteoswiss-content-data.js';
 import { debugTools } from '../support/logging.js';
 
@@ -12,7 +12,7 @@ import { debugTools } from '../support/logging.js';
  * @param input Fetch parameters
  * @returns Content with optional metadata
  */
-export async function meteoswissFetchTool(input: unknown): Promise<unknown> {
+export async function meteoswissFetchTool(input: unknown): Promise<ContentResponse> {
   debugTools('Fetch tool called with input: %O', input);
 
   // Validate input


### PR DESCRIPTION
## Summary

Migrates all 7 tool registrations from the deprecated `server.tool()` to `registerTool()` with declared Zod `outputSchema`:

- `tools/list` now advertises each tool's **full response shape** with per-field descriptions (previously only input schemas were protocol-visible; response shapes were hand-written TS types invisible to clients).
- Every success response now includes MCP **`structuredContent`**, validated by the SDK against the declared schema on each call. The JSON text `content` stays alongside it for compatibility. Error paths unchanged (`isError`, content-only — the SDK explicitly skips output validation there).
- **Response shapes unchanged**: the old TS types became Zod schemas with the same exported names via `z.infer`, so the data layer's return-type annotations prove schema↔runtime equivalence at compile time. The rich JSDoc field semantics (e.g. `hourly: null` vs `[]`, station-vs-postal-code sourcing caveats) moved into `.describe()` and are now machine-readable.

## Why now

STEP A (resolved decision 1) of the skills↔MCP parity plan (#119): the parity lint's source of truth is the generated `tools/list` inventory, and Max decided output shape must be part of that generated surface before the lint lands. Independently valuable regardless — MCP clients get machine-readable output contracts.

## Verification

- `pnpm run fix && pnpm run ci` green — 22 suites, 205 passed, 1 pre-existing skip (documented macOS port-mapping flake).
- Integration suite runs through a real MCP client harness, so SDK output validation executed against fixture data for every tool call.
- Direct in-process probe: all 7 tools advertise `outputSchema` in `tools/list`; live `callTool('meteoswissStations', …)` returned validated `structuredContent`.

## Changeset

`meteoswiss-mcp`: minor (additive — structured output + advertised output schemas).

Sessionlog: `docs/sessionlogs/2026-07-11-register-tool-output-schemas.md` (in this PR per policy).

Part of #119 (STEP B `infra/skills-parity-lint` is blocked on this landing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
