### PR TITLE
docs: correct 1.0.0 CHANGELOG date to true MVP ship date

### DIFF
--- a/docs/sessionlogs/2026-07-11-fix-1.0.0-changelog-date.md
+++ b/docs/sessionlogs/2026-07-11-fix-1.0.0-changelog-date.md
@@ -1,0 +1,13 @@
+# Fix 1.0.0 CHANGELOG date
+
+**Date:** 2026-07-11
+**Model:** Claude Opus 4.8 (worktree `changelog-backfill`, branch `docs/fix-1.0.0-changelog-date`)
+
+Corrected `1.0.0`'s historical release date `2026-03-29` → `2025-06-09` (true MVP ship date) in
+`packages/meteoswiss-mcp/CHANGELOG.md`. The `2026-03-29` value was a tag-recreation artifact from
+the monorepo restructure; npm publish times confirmed all `2.0.0`–`2.3.2` dates are already
+correct, so only `1.0.0` (never published to npm) needed the fix.
+
+Docs-only correction to a historical entry — **no changeset** (a changeset would wrongly trigger
+a version bump). `changeset version` only prepends new entries, so hand-editing a past entry's
+date is safe and won't be clobbered by future releases.

--- a/packages/meteoswiss-mcp/CHANGELOG.md
+++ b/packages/meteoswiss-mcp/CHANGELOG.md
@@ -82,7 +82,7 @@
   - **Transport**: Migrate from SSE to MCP Streamable HTTP (SDK 1.28+)
   - **Dependencies**: Upgrade to Zod 4
 
-## 1.0.0 - 2026-03-29
+## 1.0.0 - 2025-06-09
 
 ### Major Changes
 


### PR DESCRIPTION
## Summary

Corrects `1.0.0`'s historical release date in `packages/meteoswiss-mcp/CHANGELOG.md`:

```diff
-## 1.0.0 - 2026-03-29
+## 1.0.0 - 2025-06-09
```

The `2026-03-29` value was a tag-recreation artifact from the monorepo restructure. The MVP actually shipped **2025-06-09**. An npm cross-check confirmed every other row (`2.0.0`–`2.3.2`) is already correctly dated against its publish time; `1.0.0` was never published to npm, so it's the only row that needed fixing.

## Notes

- **No changeset** — this is a docs correction to a *historical* entry, not a new release. A changeset would wrongly trigger a version bump. `changeset version` only prepends new entries, so hand-editing a past entry's date is safe and won't be clobbered.
- Sessionlog `docs/sessionlogs/2026-07-11-fix-1.0.0-changelog-date.md` included per standing policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
