### PR TITLE
ci: dynamic Version Packages PR title + RC pre-release comments

### DIFF
--- a/.github/scripts/comment-prerelease-pr.sh
+++ b/.github/scripts/comment-prerelease-pr.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Posts a comment on the open Version Packages PR (if any) announcing a
+# freshly-published pre-release, so RC publishes stay visible from the PR
+# that will eventually cut the real release. No-ops cleanly if there's no
+# open Version Packages PR at the time (nothing pending).
+#
+# Usage: comment-prerelease-pr.sh <package-name> <version>
+set -euo pipefail
+
+PACKAGE_NAME="${1:?usage: comment-prerelease-pr.sh <package-name> <version>}"
+VERSION="${2:?usage: comment-prerelease-pr.sh <package-name> <version>}"
+
+PR_NUMBER=$(gh pr list --head changeset-release/main --state open --json number -q '.[0].number')
+
+if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+  echo "No open Version Packages PR found for changeset-release/main; skipping comment." >&2
+  exit 0
+fi
+
+gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
+🚀 Published pre-release **${PACKAGE_NAME}@${VERSION}** to npm under the \`next\` dist-tag:
+https://www.npmjs.com/package/${PACKAGE_NAME}/v/${VERSION}
+EOF
+)"

--- a/.github/scripts/compute-version-pr-title.sh
+++ b/.github/scripts/compute-version-pr-title.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Computes a "release <name> v<version>, <name> v<version>" title for the
+# changesets Version Packages PR, by diffing each workspace package's
+# package.json against the ref changesets/action just bumped versions on,
+# then sets it via `gh pr edit`.
+#
+# Usage: compute-version-pr-title.sh <git-ref-with-bumped-versions> <pr-number>
+set -euo pipefail
+
+REF="${1:?usage: compute-version-pr-title.sh <git-ref-with-bumped-versions> <pr-number>}"
+PR_NUMBER="${2:?usage: compute-version-pr-title.sh <git-ref-with-bumped-versions> <pr-number>}"
+
+releases=()
+for pkg_json in packages/*/package.json; do
+  [ -f "$pkg_json" ] || continue
+
+  is_private=$(jq -r '.private // false' "$pkg_json")
+  [ "$is_private" = "true" ] && continue
+
+  name=$(jq -r '.name' "$pkg_json")
+  old_version=$(jq -r '.version' "$pkg_json")
+  new_version=$(git show "${REF}:${pkg_json}" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)
+
+  if [ -n "$new_version" ] && [ "$new_version" != "$old_version" ]; then
+    releases+=("${name} v${new_version}")
+  fi
+done
+
+if [ "${#releases[@]}" -eq 0 ]; then
+  echo "No package version changes detected between HEAD and ${REF}; leaving PR title as-is." >&2
+  exit 0
+fi
+
+printf -v joined '%s, ' "${releases[@]}"
+joined="${joined%, }"
+title="release ${joined}"
+
+# Keep the title readable even with many packages in the release.
+MAX_LEN=200
+if [ "${#title}" -gt "$MAX_LEN" ]; then
+  more=$(( ${#releases[@]} - 1 ))
+  title="release ${releases[0]} and ${more} more package(s)"
+fi
+
+echo "Setting PR #${PR_NUMBER} title to: ${title}"
+gh pr edit "${PR_NUMBER}" --title "${title}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -114,6 +115,15 @@ jobs:
           else
             npm publish --access public --provenance
           fi
+
+      - name: Comment pre-release on Version Packages PR
+        # Keeps RC publishes visible from the standing Version Packages PR;
+        # no-ops cleanly if there's no open PR at the time.
+        if: steps.version.outputs.prerelease == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+        run: .github/scripts/comment-prerelease-pr.sh meteoswiss-mcp "$PACKAGE_VERSION"
 
   publish-docker:
     name: Publish to GHCR

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -37,6 +37,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Create or update version PR
+        id: changesets
         uses: changesets/action@c8bada60c408975afd1a20b3db81d6eee6789308 # v1
         with:
           title: 'Version Packages'
@@ -47,3 +48,14 @@ jobs:
           version: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set dynamic Version Packages PR title
+        # Only runs when changesets/action actually created/updated a PR —
+        # a push with no pending changesets leaves pullRequestNumber unset.
+        if: steps.changesets.outputs.pullRequestNumber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
+        run: |
+          git fetch origin changeset-release/main
+          .github/scripts/compute-version-pr-title.sh origin/changeset-release/main "$PR_NUMBER"

--- a/docs/sessionlogs/2026-07-18-changesets-release-visibility.md
+++ b/docs/sessionlogs/2026-07-18-changesets-release-visibility.md
@@ -1,0 +1,35 @@
+# Changesets release-visibility improvements (dynamic PR title + RC comment)
+
+**Date:** 2026-07-18
+**Source:** Claude Code (Opus 4.8, autonomous)
+**Session:** Single-session implementation, no compaction
+
+## Summary
+Implemented two release-visibility improvements to the changesets CI wiring, both requested together: (1) the "Version Packages" PR title now lists the packages + their new versions instead of the static "Version Packages" default, and (2) each RC pre-release publish now posts a comment on the open Version Packages PR announcing the new version + npm link. Pure CI/infra change — no product code touched, no changeset entry (per repo convention, changesets are for user-facing package changes only).
+
+## Key Accomplishments
+- **`.github/workflows/version-packages.yml`**: gave the `changesets/action` step an `id: changesets`, then added a follow-up step that runs only when the action's `pullRequestNumber` output is set (i.e. it actually created/updated a PR). That step fetches `origin/changeset-release/main` and calls a new script to diff bumped `package.json` versions and set the PR title via `gh pr edit`.
+- **`.github/workflows/release.yml`**: added `pull-requests: write` to the `publish-npm` job's permissions, and a step right after `npm publish --tag next` (gated on `steps.version.outputs.prerelease == 'true'`) that finds the open Version Packages PR (`gh pr list --head changeset-release/main --state open`) and posts a comment with the new RC version + npm link.
+- **New scripts** (`.github/scripts/compute-version-pr-title.sh`, `.github/scripts/comment-prerelease-pr.sh`): extracted the logic out of inline YAML so it's independently testable and shellcheck-able, and so the workflow `run:` blocks stay simple pass-throughs.
+- Confirmed the exact `changesets/action` output names (`published`, `publishedPackages`, `hasChangesets`, `pullRequestNumber`) by fetching `action.yml` directly from the pinned SHA (`c8bada6...`, tagged `v1`) rather than trusting newer v2-era docs that use dash-case names — the two generations of the action's docs disagree and only the pinned commit's actual `action.yml` is authoritative for this repo.
+- Confirmed private-package exclusion is necessary: `packages/meteoswiss-forecast-evals` (`private: true`, version `0.1.0`, not a pnpm workspace member) would otherwise show up if it ever picked up a stray version bump.
+
+## Decisions
+- **Extracted shell logic into `.github/scripts/*.sh`** rather than inlining in the workflow YAML, specifically so the title-computation and PR-finding logic could be dry-run locally with a mocked version bump and a stub `gh`, per the task's "don't trigger a real release to test" constraint.
+- **Diff-based title computation** (compare each workspace package's local `package.json` version against the same path read from `origin/changeset-release/main` via `git show`) rather than trying to parse `changeset status` output — simpler, and works whether or not the local checkout was left in a bumped state by the action.
+- **Truncate to "release X and N more package(s)"** past 200 characters, to keep the title readable if the package count grows — a minimal safety cap, not overbuilt.
+- **Routed all `${{ steps.*.outputs.* }}` values through `env:` blocks** rather than interpolating directly into `run:` command strings, per this repo's GitHub Actions security-reminder hook (defense-in-depth, even though these specific outputs — a PR number and a semver string — aren't attacker-controlled).
+- **No changeset entry** — per the task's explicit instruction and existing convention, CI/release-tooling wiring is a plain commit, not a user-facing package change.
+
+## Verification
+- `actionlint` (v1.7.12, downloaded to a scratch dir — not installed system-wide) ran clean against both modified workflow files, including its embedded shellcheck pass over the `run:` blocks.
+- `shellcheck` ran clean against both new scripts directly.
+- **`compute-version-pr-title.sh`** dry-run tested against a throwaway commit built via `git hash-object`/`git update-index --cacheinfo`/`git commit-tree` (pure plumbing — never touched the real working tree, index, or HEAD): confirmed correct output `release meteoswiss-mcp v3.0.0-rc.0, meteoswiss-skills v1.1.0-rc.0`, confirmed the private `meteoswiss-forecast-evals` package is excluded even when bumped, confirmed a clean no-op (exit 0) when the ref has no version changes, and unit-tested the >200-char truncation branch in isolation.
+- **`comment-prerelease-pr.sh`** dry-run tested against a stub `gh` binary (prepended to `PATH`, not the real CLI): confirmed the correct comment body/PR-number path when a PR is "found", and a clean no-op (exit 0) when `gh pr list` returns no match.
+- Did **not** trigger any real release, publish, or PR-mutating action — everything above was tested via mocks/plumbing per the task's explicit instruction.
+
+## Not Tested (would need a real release)
+- The actual GitHub-hosted runner environment (`gh` auth via `GH_TOKEN`, `git fetch` against the real `changeset-release/main` branch, real `changesets/action` output wiring end-to-end). The dry-runs validate the shell logic in isolation; the first real run of these two steps in Actions is the first time the full integration (action output → env var → script) executes for real.
+
+## Next Steps
+- Max reviews and merges. No further action from the agent — idling per instruction (homebot coordinates, no `/bye`).


### PR DESCRIPTION
## Summary
- **Dynamic Version Packages PR title**: `version-packages.yml` now sets the PR title to `release <pkg> v<ver>, <pkg> v<ver>` (computed from the bumped `package.json` versions on `changeset-release/main`) instead of the static "Version Packages" default. No-ops cleanly when the changesets action doesn't create/update a PR.
- **RC visibility from the Version Packages PR**: `release.yml` now comments on the open Version Packages PR with the new version + npm link right after an RC publishes (`npm publish --tag next`), so pre-releases are visible from the PR that will eventually cut the real release. No-ops cleanly when there's no open PR.
- Shell logic extracted into `.github/scripts/compute-version-pr-title.sh` and `.github/scripts/comment-prerelease-pr.sh` so it's independently testable (and shellcheck-able) rather than inlined in YAML.
- Pure CI/infra change — no changeset entry, per repo convention (changesets are for user-facing package changes).

## Test plan
- [x] `actionlint` clean on both modified workflow files (incl. its embedded shellcheck pass over `run:` blocks)
- [x] `shellcheck` clean on both new scripts
- [x] `compute-version-pr-title.sh` dry-run against a throwaway commit built via git plumbing (`hash-object`/`update-index --cacheinfo`/`commit-tree` — never touched the real working tree/index/HEAD): correct multi-package title, private package (`meteoswiss-forecast-evals`) correctly excluded, clean no-op when nothing changed, truncation branch verified for many-package titles
- [x] `comment-prerelease-pr.sh` dry-run against a stub `gh` binary: correct comment when a PR is found, clean no-op when none is open
- [ ] First real run in Actions — the dry-runs validate the shell logic in isolation; this is genuinely first-run-in-prod for the action-output → env-var → script wiring end-to-end (noted in the sessionlog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
