### PR TITLE
fix: dynamic Version Packages PR title never fired against real disk state

### DIFF
--- a/.github/scripts/compute-version-pr-title.sh
+++ b/.github/scripts/compute-version-pr-title.sh
@@ -1,25 +1,35 @@
 #!/usr/bin/env bash
 # Computes a "release <name> v<version>, <name> v<version>" title for the
 # changesets Version Packages PR, by diffing each workspace package's
-# package.json against the ref changesets/action just bumped versions on,
-# then sets it via `gh pr edit`.
+# package.json between two git refs, then sets it via `gh pr edit`.
 #
-# Usage: compute-version-pr-title.sh <git-ref-with-bumped-versions> <pr-number>
+# Both sides are read via `git show <ref>:<path>` rather than local disk,
+# because `changesets/action` runs its version script in place: by the time
+# this script runs, the checked-out working tree is already sitting on the
+# bumped `changeset-release/main` commit, not on the pre-bump base branch.
+# Comparing local disk to that same commit always finds zero diff.
+#
+# Usage: compute-version-pr-title.sh <before-ref> <after-ref> <pr-number>
 set -euo pipefail
 
-REF="${1:?usage: compute-version-pr-title.sh <git-ref-with-bumped-versions> <pr-number>}"
-PR_NUMBER="${2:?usage: compute-version-pr-title.sh <git-ref-with-bumped-versions> <pr-number>}"
+BEFORE_REF="${1:?usage: compute-version-pr-title.sh <before-ref> <after-ref> <pr-number>}"
+AFTER_REF="${2:?usage: compute-version-pr-title.sh <before-ref> <after-ref> <pr-number>}"
+PR_NUMBER="${3:?usage: compute-version-pr-title.sh <before-ref> <after-ref> <pr-number>}"
 
 releases=()
 for pkg_json in packages/*/package.json; do
   [ -f "$pkg_json" ] || continue
 
-  is_private=$(jq -r '.private // false' "$pkg_json")
+  after_json=$(git show "${AFTER_REF}:${pkg_json}" 2>/dev/null) || continue
+
+  is_private=$(echo "$after_json" | jq -r '.private // false')
   [ "$is_private" = "true" ] && continue
 
-  name=$(jq -r '.name' "$pkg_json")
-  old_version=$(jq -r '.version' "$pkg_json")
-  new_version=$(git show "${REF}:${pkg_json}" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)
+  name=$(echo "$after_json" | jq -r '.name')
+  new_version=$(echo "$after_json" | jq -r '.version // empty')
+
+  before_json=$(git show "${BEFORE_REF}:${pkg_json}" 2>/dev/null || true)
+  old_version=$(echo "${before_json:-}" | jq -r '.version // empty' 2>/dev/null || true)
 
   if [ -n "$new_version" ] && [ "$new_version" != "$old_version" ]; then
     releases+=("${name} v${new_version}")
@@ -27,7 +37,7 @@ for pkg_json in packages/*/package.json; do
 done
 
 if [ "${#releases[@]}" -eq 0 ]; then
-  echo "No package version changes detected between HEAD and ${REF}; leaving PR title as-is." >&2
+  echo "No package version changes detected between ${BEFORE_REF} and ${AFTER_REF}; leaving PR title as-is." >&2
   exit 0
 fi
 

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -52,10 +52,17 @@ jobs:
       - name: Set dynamic Version Packages PR title
         # Only runs when changesets/action actually created/updated a PR —
         # a push with no pending changesets leaves pullRequestNumber unset.
+        #
+        # BEFORE_SHA is this push's pre-bump commit; AFTER_REF is HEAD
+        # because changesets/action already checked out and committed the
+        # version bump onto changeset-release/main in this same working
+        # tree (see its `git checkout -b` + `git reset --hard` + `git push
+        # origin HEAD:changeset-release/main` in the step above) — no
+        # fetch needed, and comparing against local disk instead of
+        # BEFORE_SHA would always show zero diff.
         if: steps.changesets.outputs.pullRequestNumber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
-        run: |
-          git fetch origin changeset-release/main
-          .github/scripts/compute-version-pr-title.sh origin/changeset-release/main "$PR_NUMBER"
+          BEFORE_SHA: ${{ github.sha }}
+        run: .github/scripts/compute-version-pr-title.sh "$BEFORE_SHA" HEAD "$PR_NUMBER"

--- a/docs/sessionlogs/2026-07-18-changesets-title-fix.md
+++ b/docs/sessionlogs/2026-07-18-changesets-title-fix.md
@@ -1,0 +1,26 @@
+# Fix: dynamic Version Packages PR title always fell back to the static default
+
+**Date:** 2026-07-18
+**Source:** Claude Code (Opus 4.8, autonomous)
+**Session:** Follow-up to PR #135, triggered by Max asking to verify the merged feature actually worked
+
+## Summary
+Max merged #135 (dynamic "Version Packages" PR title + RC visibility comments) and asked me to verify it against a real trigger: PR #131 merged right after, carrying a `meteoswiss-skills` changeset, which caused `version-packages.yml` to run for real. The dynamic-title step ran without erroring, but PR #117's title stayed the static `"Version Packages"` — the feature silently no-op'd instead of firing. Root-caused and fixed in this PR.
+
+## Root Cause
+`compute-version-pr-title.sh` compared **local disk** `package.json` files (as the "before" state) against `origin/changeset-release/main` (the "after" state). This assumption was wrong: `changesets/action`'s "Create or update version PR" step does its version bump **in place** in the same job's working tree — its own log shows `git checkout -b changeset-release/main`, `git reset --hard <trigger-sha>`, runs `pnpm run version` (bumping local `package.json` files), commits, then `git push origin HEAD:changeset-release/main --force`. By the time my follow-up step ran, local disk was *already* sitting on the bumped `changeset-release/main` commit — identical to what I was diffing it against. The comparison was always `X == X`, so the script always reported "no changes detected" and left the static title in place. Confirmed directly from the Actions log of the run triggered by PR #131's merge (`gh run view 29649585326 --log`).
+
+## Fix
+Changed the script to take two explicit git refs (`<before-ref> <after-ref>`) instead of one ref + local disk, and read **both** sides via `git show <ref>:<path>` — never touching local disk state. The workflow now passes `github.sha` (this push's guaranteed pre-bump commit) as `BEFORE_SHA` and `HEAD` as the after-ref (which, per the trace above, is reliably the bumped commit once `changesets/action` has run). This also let me drop the now-unnecessary `git fetch origin changeset-release/main` step — `HEAD` already has everything needed locally.
+
+## Verification
+- `shellcheck` and `actionlint` (same setup as PR #135) both clean.
+- Reproduced the **exact** original bug via git plumbing: built two throwaway commits (`git hash-object` / `update-index --cacheinfo` / `commit-tree`, never touching the real working tree) — one at the real pre-bump `main` HEAD (`7eba09e`, the actual commit PR #131 merged into), one with mocked bumped versions. Running the *fixed* script with `(before, after)` = `(7eba09e, mock-bump)` correctly produced `release meteoswiss-mcp v3.0.0, meteoswiss-skills v1.1.0`. Running it with `(before, after)` = `(mock-bump, mock-bump)` — simulating the exact "local disk already bumped" condition that broke production — reproduced the original silent no-op, confirming the root cause.
+- Private-package exclusion (`meteoswiss-forecast-evals`) and the no-op/truncation paths are unchanged logic and were re-verified in the same dry-run.
+- Did not trigger a real release to test, per the same constraint as PR #135 — the next real merge with a pending changeset is the real integration test.
+
+## What This Means For PR #117 Right Now
+PR #117 ("Version Packages") is still titled `Version Packages` on `main` as of this fix — that's expected; nothing will retitle it until the next push to `main` re-runs `version-packages.yml` with this fix in place. The RC pre-release-comment feature (the other half of #135) hasn't been exercised yet either way, since no RC has been published since #135 merged — it's independent of this bug and still believed correct (it doesn't do a before/after `package.json` diff at all, just reads the tag-derived version straight from `steps.version.outputs.version`).
+
+## Next Steps
+- Max reviews and merges. The next `main` push carrying a changeset (or the next Version Packages PR update) is what will actually confirm the fix in production — worth checking PR #117's title again after that.


### PR DESCRIPTION
## Summary
- Fixes the dynamic Version Packages PR title feature from #135, which merged but never actually fired: verified against the real trigger (PR #131's merge, carrying a `meteoswiss-skills` changeset) and found PR #117's title stayed the static `"Version Packages"`.
- **Root cause**: the title script diffed local disk `package.json` against `origin/changeset-release/main`, but `changesets/action` bumps local disk *in place* before pushing (its own log shows `checkout -b` + `reset --hard` + version + commit + `push HEAD:changeset-release/main`) — so by the time the follow-up step ran, local disk and the remote branch were identical, and the diff always found nothing.
- **Fix**: read both "before" (`github.sha`, this push's pre-bump commit) and "after" (`HEAD`) states via `git show <ref>:<path>`, never local disk. Drops the now-unneeded `git fetch`.
- The RC-comment half of #135 is unaffected/untouched — it doesn't diff `package.json` at all, just reads the tag-derived version directly.

## Test plan
- [x] `shellcheck` + `actionlint` clean
- [x] Reproduced the **exact** production bug via git plumbing (two throwaway commits, real tree never touched): running the fixed script with `(before, after) = (mock, mock)` — simulating "local disk already bumped" — reproduces the original silent no-op, confirming root cause
- [x] Running the fixed script with the real `(before, after) = (7eba09e, mock-bump)` pair produces the correct `release meteoswiss-mcp v3.0.0, meteoswiss-skills v1.1.0`
- [x] Private-package exclusion and no-op/truncation paths re-verified (unchanged logic)
- [ ] Next real push to `main` carrying a changeset is the true integration test — worth checking PR #117's title after this merges and something lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
