### PR TITLE
fix(deps): bump js-yaml to ^5.2.2, drop its audit suppression (age-gated until ~22:55 UTC)

### DIFF
--- a/docs/sessionlogs/2026-07-24-js-yaml-5.2.2-fast-follow.md
+++ b/docs/sessionlogs/2026-07-24-js-yaml-5.2.2-fast-follow.md
@@ -1,0 +1,27 @@
+# Fast-follow: bump js-yaml to 5.2.2, drop its audit suppression
+
+**Date:** 2026-07-24
+**Source:** Claude Code (Opus 4.8, 1M context)
+**Session:** Fast-follow to PR #138 / the 3.0.0 release. PR: (this branch `fix/js-yaml-5.2.2-fast-follow`).
+
+## Summary
+PR #138 shipped the 3.0.0 Docker/security fix but documented-suppressed the js-yaml HIGH advisory (`GHSA-pm4m-ph32-ghv5`, CVE — "Exponential parsing time in flow collections", vulnerable `>=5.0.0 <=5.2.1`, patched `>=5.2.2`) because js-yaml@5.2.2 was still inside pnpm's 24h `minimumReleaseAge` window at merge time. This PR closes that suppression now that the patched version is (about to be) old enough.
+
+## Change
+- `packages/meteoswiss-mcp/package.json`: `js-yaml` devDependency `^5.2.1` → `^5.2.2`.
+- Root `package.json`: removed **only** the `GHSA-pm4m-ph32-ghv5` (js-yaml) entry from `pnpm.auditConfig.ignoreGhsas`. The `GHSA-frvp-7c67-39w9` (@hono/node-server) suppression is **left in place** — that advisory is a Windows-only path traversal and the deployment is Linux/Docker, and `≥2.0.5` is a breaking `1.x→2.x` bump on an MCP-SDK transitive dep.
+- `pnpm-lock.yaml`: regenerated; `js-yaml@5.2.2` now locked.
+
+js-yaml is a **devDependency** — it is not in the production image (`pnpm deploy --prod` excludes it), so this changes no shipped runtime behavior. No changeset (dev-tooling per CLAUDE.md).
+
+## Timing / expected CI state (important)
+js-yaml@5.2.2 was published **2026-07-23T22:55Z**; pnpm's `minimumReleaseAge` (24h) is enforced in CI (the Docker build's frozen fetch, and any `pnpm install --frozen-lockfile` that verifies lockfile entries). Until **~2026-07-24T22:55Z**, CI (Docker Build Test, Security & Dependency Check, and the other frozen-install jobs) will **FAIL** on `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` for `js-yaml@5.2.2`. **This is expected and must not be "fixed" by weakening the age policy.** After the cutoff, CI passes naturally with no further changes. Merge this PR once CI is green (targeted for the Renovate pass later tonight).
+
+## Verification (local — age gate is a CI-only enforcement)
+- `pnpm install` resolved js-yaml@5.2.2 into the lockfile (local pnpm does not enforce the age gate).
+- `pnpm audit --audit-level moderate` exits **0** — the js-yaml HIGH is gone (patched), only the documented `@hono/node-server` moderate remains ignored, plus 4 sub-threshold LOW.
+- `pnpm --filter meteoswiss-mcp run ci` green (lint + build + 250 tests) — the js-yaml patch bump breaks nothing.
+
+## Next Steps
+- Leave the PR open until ~22:55 UTC; merge when CI naturally goes green.
+- `@hono/node-server` suppression remains tracked; revisit only if it ever leaves dev/Windows-only scope.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     },
     "auditConfig": {
       "ignoreGhsas": [
-        "GHSA-pm4m-ph32-ghv5",
         "GHSA-frvp-7c67-39w9"
       ]
     }

--- a/packages/meteoswiss-mcp/package.json
+++ b/packages/meteoswiss-mcp/package.json
@@ -95,7 +95,7 @@
     "globals": "^17.4.0",
     "jest": "^30.3.0",
     "jest-environment-node": "^30.3.0",
-    "js-yaml": "^5.2.1",
+    "js-yaml": "^5.2.2",
     "mcp-remote": "^0.1.38",
     "nock": "^14.0.11",
     "nodemon": "^3.1.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,8 +148,8 @@ importers:
         specifier: ^30.3.0
         version: 30.3.0
       js-yaml:
-        specifier: ^5.2.1
-        version: 5.2.1
+        specifier: ^5.2.2
+        version: 5.2.2
       mcp-remote:
         specifier: ^0.1.38
         version: 0.1.38
@@ -2811,8 +2811,8 @@ packages:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   jsdom@24.1.3:
@@ -7063,7 +7063,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@5.2.1:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Fast-follow to #138 / the 3.0.0 release

#138 documented-suppressed the **js-yaml HIGH** advisory (`GHSA-pm4m-ph32-ghv5` — "Exponential parsing time in flow collections"; vulnerable `>=5.0.0 <=5.2.1`, patched `>=5.2.2`) because js-yaml@5.2.2 was still inside pnpm's 24h `minimumReleaseAge` window at merge time. This closes that suppression.

## Change
- `packages/meteoswiss-mcp/package.json`: `js-yaml` devDep `^5.2.1` → **`^5.2.2`**
- Root `package.json`: removed **only** the `GHSA-pm4m-ph32-ghv5` (js-yaml) entry from `pnpm.auditConfig.ignoreGhsas`. **`GHSA-frvp-7c67-39w9` (@hono/node-server) stays** — Windows-only path traversal, Linux/Docker deployment, and `≥2.0.5` is a breaking `1.x→2.x` bump on an MCP-SDK transitive dep.
- `pnpm-lock.yaml` regenerated (`js-yaml@5.2.2` locked)

js-yaml is **dev-only** (excluded from the prod image via `pnpm deploy --prod`) — no shipped runtime change, no changeset.

## ⏳ Expected CI state — do NOT force green
js-yaml@5.2.2 was published **2026-07-23T22:55Z**. pnpm's `minimumReleaseAge` (24h) is enforced in CI, so until **~2026-07-24T22:55Z** the frozen-install jobs (**Docker Build Test**, **Security & Dependency Check**, etc.) will **fail** with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` on `js-yaml@5.2.2`. **This is expected.** After the cutoff, CI passes with no further changes — **merge once CI is naturally green** (targeted for the Renovate pass later tonight). The age policy must not be weakened to force this.

## Verification (local — the age gate is a CI-only enforcement)
- `pnpm install` locks `js-yaml@5.2.2`
- `pnpm audit --audit-level moderate` exits **0** — js-yaml HIGH gone; only the documented `@hono/node-server` moderate remains ignored (+ 4 sub-threshold LOW)
- `pnpm --filter meteoswiss-mcp run ci` green (lint + build + 250 tests)

Sessionlog: `docs/sessionlogs/2026-07-24-js-yaml-5.2.2-fast-follow.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
